### PR TITLE
Task #15: SVG 디버그 오버레이 추가 (--svg --debug-overlay)

### DIFF
--- a/crates/rpdf-cli/src/commands/render.rs
+++ b/crates/rpdf-cli/src/commands/render.rs
@@ -14,13 +14,19 @@ pub struct RenderParams {
     pub scale: f32,
     /// SVG 출력 모드. `true`면 pdfium 불필요.
     pub svg: bool,
+    /// `true`면 SVG에 좌표 그리드·페이지 경계·원점 마커를 추가한다 (`--svg` 전용).
+    pub debug_overlay: bool,
 }
 
 /// `rpdf render` 서브커맨드를 실행한다.
 ///
 /// `--svg` 미지정: `PDFIUM_DYNAMIC_LIB_PATH` 환경변수 필요.
-/// `--svg` 지정: `rpdf_parser::load_document()` → `rpdf_svg::render_page_svg()` → SVG 파일 저장.
+/// `--svg` 지정: `rpdf_parser::load_document()` → `rpdf_svg::render_page_svg_with_options()` → SVG 파일 저장.
+/// `--debug-overlay` + `--svg` 미지정: stderr에 경고를 출력하고 PNG 생성을 계속 진행한다.
 pub fn run(params: RenderParams) -> Result<()> {
+    if params.debug_overlay && !params.svg {
+        eprintln!("Warning: --debug-overlay has no effect without --svg");
+    }
     if params.svg {
         run_svg(params)
     } else {
@@ -68,7 +74,7 @@ fn run_png(params: RenderParams) -> Result<()> {
 }
 
 fn run_svg(params: RenderParams) -> Result<()> {
-    use rpdf_svg::render_page_svg;
+    use rpdf_svg::{RenderOptions, render_page_svg_with_options};
 
     let data = std::fs::read(&params.file)
         .with_context(|| format!("파일을 읽을 수 없습니다: {}", params.file.display()))?;
@@ -85,7 +91,10 @@ fn run_svg(params: RenderParams) -> Result<()> {
         )
     })?;
 
-    let svg_content = render_page_svg(page);
+    let opts = RenderOptions {
+        debug_overlay: params.debug_overlay,
+    };
+    let svg_content = render_page_svg_with_options(page, &opts);
 
     let output_path = match params.output {
         Some(p) => p,

--- a/crates/rpdf-cli/src/main.rs
+++ b/crates/rpdf-cli/src/main.rs
@@ -66,6 +66,9 @@ enum Commands {
         /// SVG 출력 모드 (pdfium 불필요).
         #[arg(long = "svg")]
         svg: bool,
+        /// SVG 출력 시 좌표 그리드·페이지 경계·원점 마커 추가 (--svg 전용).
+        #[arg(long = "debug-overlay")]
+        debug_overlay: bool,
     },
 }
 
@@ -100,12 +103,14 @@ fn run(cli: Cli) -> Result<()> {
             page,
             scale,
             svg,
+            debug_overlay,
         } => commands::render::run(commands::render::RenderParams {
             file,
             output,
             page,
             scale,
             svg,
+            debug_overlay,
         }),
     }
 }

--- a/crates/rpdf-cli/tests/render_tests.rs
+++ b/crates/rpdf-cli/tests/render_tests.rs
@@ -165,3 +165,62 @@ fn it_s5_render_svg_no_pdfium_needed() {
         .assert()
         .success();
 }
+
+// IT-D4: rpdf render pdfjs-basicapi.pdf --svg --debug-overlay → id="debug-overlay" 포함
+#[test]
+fn it_d4_render_svg_debug_overlay_contains_overlay_group() {
+    let out = tempfile::Builder::new()
+        .suffix(".svg")
+        .tempfile()
+        .expect("tempfile 생성 실패");
+    let out_path = out.path().to_string_lossy().into_owned();
+
+    rpdf()
+        .args([
+            "render",
+            &pdf("pdfjs-basicapi.pdf"),
+            "--svg",
+            "--debug-overlay",
+            "-o",
+            &out_path,
+        ])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&out_path).expect("SVG 파일 읽기 실패");
+    assert!(
+        content.contains("id=\"debug-overlay\""),
+        "debug-overlay 그룹 없음: {}",
+        &content[..content.len().min(500)]
+    );
+}
+
+// IT-D5: rpdf render pdfjs-basicapi.pdf --debug-overlay (--svg 없음) → stderr에 Warning: 포함
+#[test]
+fn it_d5_debug_overlay_without_svg_warns() {
+    if !has_pdfium() {
+        // PDFIUM 없을 때는 PNG 렌더링 자체가 실패하지만 warning은 출력된다
+        rpdf()
+            .env_remove("PDFIUM_DYNAMIC_LIB_PATH")
+            .args(["render", &pdf("pdfjs-basicapi.pdf"), "--debug-overlay"])
+            .assert()
+            .stderr(predicates::str::contains("Warning:"));
+    } else {
+        let out = tempfile::Builder::new()
+            .suffix(".png")
+            .tempfile()
+            .expect("tempfile 생성 실패");
+        let out_path = out.path().to_string_lossy().into_owned();
+
+        rpdf()
+            .args([
+                "render",
+                &pdf("pdfjs-basicapi.pdf"),
+                "--debug-overlay",
+                "-o",
+                &out_path,
+            ])
+            .assert()
+            .stderr(predicates::str::contains("Warning:"));
+    }
+}

--- a/crates/rpdf-svg/src/lib.rs
+++ b/crates/rpdf-svg/src/lib.rs
@@ -1,9 +1,11 @@
+mod overlay;
 mod path;
 mod state;
 mod text;
 
 use rpdf_core::types::{ContentStreamOperator, Page, PdfObject};
 
+use overlay::build_overlay;
 use path::PathBuilder;
 use state::{Color, StateStack};
 use text::TextState;
@@ -12,17 +14,38 @@ use text::TextState;
 const A4_WIDTH: f64 = 595.0;
 const A4_HEIGHT: f64 = 842.0;
 
+/// 렌더링 옵션.
+#[derive(Default)]
+pub struct RenderOptions {
+    /// `true`면 페이지 경계·좌표 그리드·원점 마커를 SVG에 추가한다.
+    pub debug_overlay: bool,
+}
+
 /// `Page` IR을 SVG 문자열로 렌더링한다.
 ///
 /// - media_box가 없으면 A4 크기(595 × 842 pt)를 기본값으로 사용한다.
 /// - 지원하지 않는 연산자는 SVG 주석으로 기록하고 계속 진행한다.
 /// - 빈 content 페이지도 유효한 `<svg>` 루트를 반환한다 (에러 아님).
 pub fn render_page_svg(page: &Page) -> String {
+    render_page_svg_with_options(page, &RenderOptions::default())
+}
+
+/// 옵션을 지정해 `Page` IR을 SVG 문자열로 렌더링한다.
+///
+/// `opts.debug_overlay`가 `true`면 페이지 경계·좌표 그리드·원점 마커를
+/// y-flip 그룹 **바깥**의 독립 레이어에 추가한다.
+pub fn render_page_svg_with_options(page: &Page, opts: &RenderOptions) -> String {
     let (w, h) = viewport(page);
     let body = render_body(page);
 
+    let overlay_str = if opts.debug_overlay {
+        build_overlay(w, h)
+    } else {
+        String::new()
+    };
+
     format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{w}\" height=\"{h}\" viewBox=\"0 0 {w} {h}\">\n<g transform=\"matrix(1 0 0 -1 0 {h})\">\n{body}</g>\n</svg>",
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{w}\" height=\"{h}\" viewBox=\"0 0 {w} {h}\">\n<g transform=\"matrix(1 0 0 -1 0 {h})\">\n{body}</g>\n{overlay_str}</svg>",
         w = fmt_f64(w),
         h = fmt_f64(h),
     )

--- a/crates/rpdf-svg/src/overlay.rs
+++ b/crates/rpdf-svg/src/overlay.rs
@@ -1,0 +1,118 @@
+/// 디버그 오버레이 SVG 문자열을 생성한다.
+///
+/// 반환값은 `<g id="debug-overlay">...</g>` 요소 전체 문자열.
+/// PDF 좌표계(좌하단 기준)를 SVG 좌표계(좌상단 기준)로 변환해 그리드·경계·원점을 배치한다.
+pub(crate) fn build_overlay(w: f64, h: f64) -> String {
+    let mut out = String::new();
+    out.push_str("<g id=\"debug-overlay\">\n");
+
+    // 1. 페이지 경계 사각형
+    out.push_str(&format!(
+        "<rect x=\"0.5\" y=\"0.5\" width=\"{}\" height=\"{}\" \
+         fill=\"none\" stroke=\"rgba(0,0,255,0.6)\" \
+         stroke-width=\"1.5\" stroke-dasharray=\"6 3\"/>\n",
+        w - 1.0,
+        h - 1.0,
+    ));
+
+    // 2. 좌표 그리드 (100pt 간격)
+    // x: 100, 200, ... (w 미만)
+    let mut x = 100.0_f64;
+    while x < w {
+        let svg_x = x;
+        out.push_str(&format!(
+            "<line x1=\"{}\" y1=\"0\" x2=\"{}\" y2=\"{}\" \
+             stroke=\"rgba(128,128,128,0.3)\" stroke-width=\"0.5\"/>\n",
+            svg_x, svg_x, h,
+        ));
+        out.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" font-size=\"9\" fill=\"rgba(0,0,200,0.7)\" \
+             font-family=\"monospace\">{}</text>\n",
+            svg_x + 3.0,
+            h - 4.0,
+            x as u32,
+        ));
+        x += 100.0;
+    }
+
+    // y: 100, 200, ... (h 미만). SVG y 좌표 = h - pdf_y
+    let mut y = 100.0_f64;
+    while y < h {
+        let svg_y = h - y;
+        out.push_str(&format!(
+            "<line x1=\"0\" y1=\"{}\" x2=\"{}\" y2=\"{}\" \
+             stroke=\"rgba(128,128,128,0.3)\" stroke-width=\"0.5\"/>\n",
+            svg_y, w, svg_y,
+        ));
+        out.push_str(&format!(
+            "<text x=\"4\" y=\"{}\" font-size=\"9\" fill=\"rgba(0,0,200,0.7)\" \
+             font-family=\"monospace\">{}</text>\n",
+            svg_y - 3.0,
+            y as u32,
+        ));
+        y += 100.0;
+    }
+
+    // 3. 원점 마커. PDF (0,0) = SVG (0, h)
+    out.push_str(&format!(
+        "<circle cx=\"0\" cy=\"{}\" r=\"5\" \
+         fill=\"rgba(255,0,0,0.7)\" stroke=\"none\"/>\n",
+        h,
+    ));
+    out.push_str(&format!(
+        "<text x=\"7\" y=\"{}\" font-size=\"10\" fill=\"rgba(200,0,0,0.9)\" \
+         font-family=\"monospace\">(0,0)</text>\n",
+        h - 4.0,
+    ));
+
+    out.push_str("</g>\n");
+    out
+}
+
+#[cfg(test)]
+mod internal_tests {
+    use super::*;
+
+    #[test]
+    fn build_overlay_contains_rect() {
+        let result = build_overlay(595.0, 842.0);
+        assert!(result.contains("<rect"), "경계 사각형 없음");
+    }
+
+    #[test]
+    fn build_overlay_contains_origin_label() {
+        let result = build_overlay(595.0, 842.0);
+        assert!(result.contains("(0,0)"), "원점 레이블 없음");
+    }
+
+    #[test]
+    fn build_overlay_contains_grid_label() {
+        let result = build_overlay(595.0, 842.0);
+        assert!(result.contains(">100<"), "그리드 레이블 없음");
+    }
+
+    #[test]
+    fn build_overlay_contains_debug_overlay_id() {
+        let result = build_overlay(595.0, 842.0);
+        assert!(
+            result.contains("id=\"debug-overlay\""),
+            "debug-overlay id 없음"
+        );
+    }
+
+    #[test]
+    fn build_overlay_small_page_no_grid_lines() {
+        let result = build_overlay(50.0, 80.0);
+        assert!(
+            !result.contains("<line"),
+            "소형 페이지에 그리드 선이 있으면 안 됨: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn build_overlay_small_page_has_rect() {
+        let result = build_overlay(50.0, 80.0);
+        assert!(result.contains("<rect"), "소형 페이지 경계 사각형 없음");
+    }
+}

--- a/crates/rpdf-svg/tests/svg_render_tests.rs
+++ b/crates/rpdf-svg/tests/svg_render_tests.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use rpdf_core::types::Page;
-use rpdf_svg::render_page_svg;
+use rpdf_svg::{RenderOptions, render_page_svg, render_page_svg_with_options};
 
 fn examples_path(name: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -80,5 +80,44 @@ fn it_s5_y_flip_transform_present() {
         svg.contains("matrix(1 0 0 -1 0"),
         "Y축 반전 transform 없음: {}",
         svg
+    );
+}
+
+// IT-D1: debug_overlay: true → id="debug-overlay" 포함
+#[test]
+fn it_d1_debug_overlay_true_contains_overlay_group() {
+    let page = load_first_page("pdfjs-basicapi.pdf");
+    let opts = RenderOptions {
+        debug_overlay: true,
+    };
+    let svg = render_page_svg_with_options(&page, &opts);
+    assert!(
+        svg.contains("id=\"debug-overlay\""),
+        "debug-overlay 그룹 없음: {}",
+        &svg[..svg.len().min(500)]
+    );
+}
+
+// IT-D2: RenderOptions::default() → id="debug-overlay" 미포함
+#[test]
+fn it_d2_debug_overlay_default_no_overlay_group() {
+    let page = load_first_page("pdfjs-basicapi.pdf");
+    let opts = RenderOptions::default();
+    let svg = render_page_svg_with_options(&page, &opts);
+    assert!(
+        !svg.contains("id=\"debug-overlay\""),
+        "기본 옵션인데 debug-overlay 그룹이 있음"
+    );
+}
+
+// IT-D3: render_page_svg() 와 render_page_svg_with_options(default) 결과 동일
+#[test]
+fn it_d3_render_page_svg_equiv_default_options() {
+    let page = load_first_page("pdfjs-basicapi.pdf");
+    let svg_legacy = render_page_svg(&page);
+    let svg_opts = render_page_svg_with_options(&page, &RenderOptions::default());
+    assert_eq!(
+        svg_legacy, svg_opts,
+        "render_page_svg()와 render_page_svg_with_options(default) 결과가 다름"
     );
 }

--- a/mydocs/plans/task15-svg-debug-overlay.md
+++ b/mydocs/plans/task15-svg-debug-overlay.md
@@ -1,0 +1,243 @@
+# Task #15 계획서: SVG 디버그 오버레이
+
+**Issue**: #28  
+**브랜치**: local/task15  
+**날짜**: 2026-05-04  
+**선행 조건**: Task #14 완료 (SVG 렌더러, PR #27 머지)
+
+---
+
+## 목표
+
+`rpdf render <pdf> --svg --debug-overlay` 명령 시  
+페이지 경계·좌표 그리드·원점 표기를 SVG 위에 시각화한다.
+
+> 디버그 오버레이는 파서 출력 좌표계 검증 전용. 인쇄용 품질 불필요.
+
+---
+
+## 완료 기준
+
+| # | 기준 |
+|---|------|
+| 1 | `rpdf-svg` 공개 API 추가: `render_page_svg_with_options(page: &Page, opts: &RenderOptions) -> String` |
+| 2 | 기존 `render_page_svg()` 함수 동작 불변 (후방 호환) |
+| 3 | `rpdf render <pdf> --svg --debug-overlay` CLI 동작 |
+| 4 | 오버레이 요소: 페이지 경계 사각형, 100pt 간격 좌표 그리드, 원점 (0,0) 마커 |
+| 5 | `cargo test`, `cargo clippy`, `cargo fmt --check` 전체 통과 |
+
+---
+
+## 공개 API 설계
+
+### `rpdf-svg` 변경
+
+```rust
+// crates/rpdf-svg/src/lib.rs
+
+/// 렌더링 옵션.
+pub struct RenderOptions {
+    /// true면 페이지 경계·좌표 그리드·원점 마커를 SVG에 추가한다.
+    pub debug_overlay: bool,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self { debug_overlay: false }
+    }
+}
+
+/// 기존 함수 — 동작 불변. RenderOptions::default()로 위임.
+pub fn render_page_svg(page: &Page) -> String {
+    render_page_svg_with_options(page, &RenderOptions::default())
+}
+
+/// 옵션을 지정해 Page IR을 SVG 문자열로 렌더링한다.
+pub fn render_page_svg_with_options(page: &Page, opts: &RenderOptions) -> String;
+```
+
+---
+
+## SVG 구조
+
+오버레이 요소는 PDF 좌표 변환 그룹 **바깥**에 배치한다.  
+PDF 콘텐츠는 y-flip 그룹 내부, 오버레이는 SVG 좌표계(좌상단 기준) 그룹에 독립 배치.
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" viewBox="0 0 {w} {h}">
+  <!-- PDF 콘텐츠 (y-flip 적용) -->
+  <g transform="matrix(1 0 0 -1 0 {h})">
+    {pdf_content}
+  </g>
+  <!-- 디버그 오버레이 (SVG 좌표계, y-flip 없음) -->
+  <g id="debug-overlay">
+    {overlay_elements}
+  </g>
+</svg>
+```
+
+---
+
+## 오버레이 요소 명세
+
+### 1. 페이지 경계 사각형
+
+페이지 전체를 둘러싸는 파란 점선 사각형.
+
+```svg
+<rect x="0.5" y="0.5" width="{w-1}" height="{h-1}"
+      fill="none" stroke="rgba(0,0,255,0.6)"
+      stroke-width="1.5" stroke-dasharray="6 3"/>
+```
+
+### 2. 좌표 그리드 (100pt 간격)
+
+PDF 좌표(좌하단 기준) 100pt 간격으로 수평·수직 가이드선 + 레이블.  
+SVG y 좌표 = `h - pdf_y`.
+
+```svg
+<!-- 수평선 (PDF y=100 → SVG y=h-100) -->
+<line x1="0" y1="{h-y}" x2="{w}" y2="{h-y}"
+      stroke="rgba(128,128,128,0.3)" stroke-width="0.5"/>
+<!-- 레이블 -->
+<text x="4" y="{h-y-3}" font-size="9" fill="rgba(0,0,200,0.7)"
+      font-family="monospace">{y}</text>
+
+<!-- 수직선 (PDF x=100 → SVG x=100) -->
+<line x1="{x}" y1="0" x2="{x}" y2="{h}"
+      stroke="rgba(128,128,128,0.3)" stroke-width="0.5"/>
+<!-- 레이블 -->
+<text x="{x+3}" y="{h-4}" font-size="9" fill="rgba(0,0,200,0.7)"
+      font-family="monospace">{x}</text>
+```
+
+그리드 생성 범위:
+- x: 100, 200, ... (w 미만)
+- y: 100, 200, ... (h 미만)
+
+### 3. 원점 마커
+
+PDF 좌표 (0,0) = SVG 좌표 (0, h) 위치에 원점 표시.
+
+```svg
+<!-- 원점 원 -->
+<circle cx="0" cy="{h}" r="5"
+        fill="rgba(255,0,0,0.7)" stroke="none"/>
+<!-- 원점 레이블 -->
+<text x="7" y="{h-4}" font-size="10" fill="rgba(200,0,0,0.9)"
+      font-family="monospace">(0,0)</text>
+```
+
+---
+
+## 모듈 설계
+
+```
+crates/rpdf-svg/
+└── src/
+    ├── lib.rs      — render_page_svg_with_options() + RenderOptions 추가
+    ├── overlay.rs  — 신규: build_overlay(w, h) -> String
+    ├── state.rs    — 변경 없음
+    ├── path.rs     — 변경 없음
+    └── text.rs     — 변경 없음
+```
+
+### overlay.rs 공개 함수
+
+```rust
+/// 디버그 오버레이 SVG 문자열을 생성한다.
+/// 반환값은 `<g id="debug-overlay">...</g>` 요소.
+pub(crate) fn build_overlay(w: f64, h: f64) -> String;
+```
+
+---
+
+## CLI 변경
+
+`crates/rpdf-cli/src/commands/render.rs`:
+
+```rust
+pub struct RenderParams {
+    pub file: PathBuf,
+    pub output: Option<PathBuf>,
+    pub page: u16,
+    pub scale: f32,
+    pub svg: bool,
+    pub debug_overlay: bool,  // 신규
+}
+```
+
+`crates/rpdf-cli/src/main.rs` — `Render` 서브커맨드에 플래그 추가:
+
+```
+--debug-overlay    SVG 출력 시 좌표 그리드·페이지 경계·원점 마커 추가 (--svg 전용)
+```
+
+`run_svg()` 내부에서 `RenderOptions { debug_overlay: params.debug_overlay }` 전달.
+
+---
+
+## 파일 목록
+
+| 파일 | 변경 |
+|------|------|
+| `crates/rpdf-svg/src/lib.rs` | `RenderOptions` 타입 + `render_page_svg_with_options()` 추가, 기존 함수 위임 |
+| `crates/rpdf-svg/src/overlay.rs` | 신규: `build_overlay()` |
+| `crates/rpdf-cli/src/commands/render.rs` | `RenderParams.debug_overlay` 추가, `run_svg()` 에 옵션 전달 |
+| `crates/rpdf-cli/src/main.rs` | `--debug-overlay` 플래그 파싱 추가 |
+
+---
+
+## 테스트 전략
+
+### 단위 테스트 (`overlay.rs` 인라인)
+
+- `build_overlay(595.0, 842.0)` 결과에 `<rect` 포함
+- `build_overlay(595.0, 842.0)` 결과에 `(0,0)` 포함 (원점 레이블)
+- `build_overlay(595.0, 842.0)` 결과에 `100` 포함 (그리드 레이블)
+- `build_overlay(595.0, 842.0)` 결과에 `id="debug-overlay"` 포함
+- `build_overlay(50.0, 80.0)` 결과에 `<line` 미포함 (소형 페이지 그리드 없음) (D2 결정)
+- `build_overlay(50.0, 80.0)` 결과에 `<rect` 포함 (경계는 표시) (D2 결정)
+
+### 통합 테스트 (`crates/rpdf-svg/tests/svg_render_tests.rs` 추가)
+
+- IT-D1: `render_page_svg_with_options(page, &RenderOptions { debug_overlay: true })` → `id="debug-overlay"` 포함
+- IT-D2: `render_page_svg_with_options(page, &RenderOptions::default())` → `id="debug-overlay"` 미포함 (후방 호환 검증)
+- IT-D3: `render_page_svg(page)` 와 `render_page_svg_with_options(page, &RenderOptions::default())` 결과 동일
+
+### CLI 테스트 (`crates/rpdf-cli/tests/render_tests.rs` 추가)
+
+- IT-D4: `rpdf render examples/pdfjs-basicapi.pdf --svg --debug-overlay` → 생성된 파일에 `id="debug-overlay"` 포함
+- IT-D5: `rpdf render examples/pdfjs-basicapi.pdf --debug-overlay` (--svg 없음) → stderr에 `Warning:` 포함 (D2 결정)
+
+---
+
+## 에지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| `--debug-overlay` + `--svg` 없음 (PNG 모드) | `eprintln!("Warning: --debug-overlay has no effect without --svg")` 출력 후 PNG 생성 진행 (D1 결정) |
+| media_box 없는 페이지 (A4 기본값 사용) | A4 (595 × 842) 기준 그리드 생성 |
+| 페이지 크기가 100 미만 | 그리드 선 없음 (100 미만 → 0개), 경계·원점만 표시 |
+
+---
+
+## 미포함 (이후 Task)
+
+- 연산자별 인덱스 번호 (각 `<path>` 옆에 순번 표시) — 범위 확대 시 추가 가능
+- 커스텀 그리드 간격 옵션 — Task #16 이후
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | 2 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **UNRESOLVED:** 0
+- **VERDICT:** ENG CLEARED — ready to implement

--- a/mydocs/working/task15-done.md
+++ b/mydocs/working/task15-done.md
@@ -1,0 +1,69 @@
+# Task #15 — SVG 디버그 오버레이 완료 보고서
+
+**Issue**: #28  
+**브랜치**: `local/task15`  
+**완료일**: 2026-05-04  
+**소요 시간**: 계획 ~3시간 / 실제 ~2시간
+
+## 완료된 작업
+
+계획서에 정의된 완료 기준 대비 결과:
+
+- [x] 기준 1: `rpdf-svg` 공개 API 추가: `render_page_svg_with_options(page: &Page, opts: &RenderOptions) -> String`
+- [x] 기준 2: 기존 `render_page_svg()` 함수 동작 불변 (IT-D3으로 동등성 검증)
+- [x] 기준 3: `rpdf render <pdf> --svg --debug-overlay` CLI 동작
+- [x] 기준 4: 오버레이 요소 3종 — 페이지 경계 사각형, 100pt 간격 좌표 그리드, 원점 (0,0) 마커
+- [x] 기준 5: `cargo test`, `cargo clippy`, `cargo fmt --check` 전체 통과
+
+## 실제 변경 사항
+
+### 새로 추가된 파일
+- `crates/rpdf-svg/src/overlay.rs` — `build_overlay(w, h) -> String` 함수 + 인라인 단위 테스트 6개
+- `mydocs/plans/task15-svg-debug-overlay.md` — 계획서
+
+### 수정된 파일
+- `crates/rpdf-svg/src/lib.rs` — `RenderOptions` 타입 + `render_page_svg_with_options()` 추가, `render_page_svg()` 위임으로 변경
+- `crates/rpdf-svg/tests/svg_render_tests.rs` — IT-D1~D3 통합 테스트 3개 추가
+- `crates/rpdf-cli/src/main.rs` — `--debug-overlay` 플래그 파싱 추가
+- `crates/rpdf-cli/src/commands/render.rs` — `RenderParams.debug_overlay` 추가, 경고 처리, `run_svg()` 옵션 전달
+- `crates/rpdf-cli/tests/render_tests.rs` — IT-D4~D5 CLI 통합 테스트 2개 추가
+
+## 계획 대비 달라진 점
+
+없음. 계획서 명세와 100% 일치. D1·D2 결정 사항 모두 반영.
+
+## 발견된 이슈
+
+없음. evaluator 검증에서 Critical/Important 항목 없음.
+
+## 배운 점
+
+### 기술적
+- SVG 오버레이를 y-flip 그룹 **바깥**에 배치하면 PDF 좌표 변환 없이 SVG 좌표 직접 사용 가능 — 오버레이 요소 좌표 계산이 단순해짐
+- `while x < w` 패턴은 소형 페이지에서 자연스럽게 그리드 없음 처리 — 별도 조건 분기 불필요
+
+### 프로세스
+- D1/D2 결정을 계획서에 명시한 덕분에 구현 시 edge case 누락 없음 — plan-eng-review가 구현 품질에 직접 기여
+
+## 테스트 결과
+
+- rpdf-svg 단위 테스트: 26/26 통과 (기존 20 + 신규 6)
+- rpdf-svg 통합 테스트: 8/8 통과 (기존 5 + 신규 3)
+- rpdf-cli 통합 테스트: 9/9 통과 (기존 7 + 신규 2)
+- `cargo clippy -- -D warnings`: 경고 없음
+- `cargo fmt --check`: 통과
+
+## 회귀 분류 표
+
+| # | 항목 요약 | 카테고리 | 판단 근거 |
+|---|---------|---------|---------|
+| 1 | 오버레이를 y-flip 그룹 바깥에 배치하는 SVG 구조 패턴 | **C: 스킵** | 이번 구현 전용 설계 결정, 일반화 규칙으로 가치 없음 |
+| 2 | while x < w 패턴으로 소형 페이지 자동 처리 | **C: 스킵** | 당연한 Rust 이터레이션 패턴, 별도 규칙 불필요 |
+
+## 다음 관련 작업
+
+- Task #16: 여러 페이지 SVG 출력
+
+## 참고 자료
+
+- 계획서: `mydocs/plans/task15-svg-debug-overlay.md`


### PR DESCRIPTION
## Summary

- \`rpdf-svg\`: \`RenderOptions { debug_overlay: bool }\` + \`render_page_svg_with_options()\` 공개 API 추가
- \`rpdf-svg\`: \`overlay.rs\` 신규 — 페이지 경계 사각형, 100pt 좌표 그리드, 원점 (0,0) 마커
- \`rpdf-cli\`: \`--debug-overlay\` 플래그 추가; \`--svg\` 없이 사용 시 \`Warning:\` 출력
- 기존 \`render_page_svg()\` 동작 불변 (후방 호환)

## Test plan

- [x] \`cargo test -p rpdf-svg\` — 34개 통과 (단위 26 + 통합 8)
- [x] \`cargo test -p rpdf-cli\` — 통합 9개 포함 전체 통과
- [x] \`cargo clippy -- -D warnings\` — 경고 없음
- [x] \`cargo fmt --check\` — 통과
- [x] \`rpdf render examples/pdfjs-basicapi.pdf --svg --debug-overlay\` — SVG에 \`id="debug-overlay"\` 포함 확인
- [x] \`rpdf render examples/pdfjs-basicapi.pdf --debug-overlay\` (--svg 없음) — stderr에 \`Warning: --debug-overlay has no effect without --svg\` 출력 확인

closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)