### PR TITLE
Task #19: DeletePagesCommand 구현

### DIFF
--- a/crates/rpdf-edit/src/commands/delete.rs
+++ b/crates/rpdf-edit/src/commands/delete.rs
@@ -1,0 +1,300 @@
+use std::sync::Mutex;
+
+use rpdf_core::types::document::{Document, Page};
+
+use crate::commands::{Command, CommandError};
+
+/// 지정한 페이지 인덱스 목록을 Document에서 제거하는 커맨드.
+///
+/// `indices`는 0-based 페이지 인덱스 목록이다. execute 시 중복 제거 + 정렬 후 처리된다.
+/// Undo 시 원래 순서대로 페이지를 복원하며, `Page.index` 필드도 재정렬된다.
+///
+/// # Examples
+///
+/// ```rust
+/// use rpdf_edit::commands::DeletePagesCommand;
+///
+/// let cmd = DeletePagesCommand::new(vec![0, 2]);
+/// ```
+pub struct DeletePagesCommand {
+    indices: Vec<usize>,
+    snapshot: Mutex<Option<Vec<(usize, Page)>>>,
+}
+
+impl DeletePagesCommand {
+    /// 새 `DeletePagesCommand`를 생성한다.
+    ///
+    /// # Arguments
+    /// * `indices` - 삭제할 0-based 페이지 인덱스 목록. 중복 허용 (자동 dedup 처리됨).
+    pub fn new(indices: Vec<usize>) -> Self {
+        Self {
+            indices,
+            snapshot: Mutex::new(None),
+        }
+    }
+}
+
+impl Command for DeletePagesCommand {
+    fn name(&self) -> &'static str {
+        "DeletePagesCommand"
+    }
+
+    fn execute(&self, doc: &mut Document) -> Result<(), CommandError> {
+        // 0. 이중 실행 방어
+        if self.snapshot.lock().unwrap().is_some() {
+            return Err(CommandError::ExecutionFailed(
+                "DeletePagesCommand already executed".to_string(),
+            ));
+        }
+
+        // 1. 정렬 후 dedup (dedup은 인접 중복만 제거하므로 sort 먼저)
+        let mut sorted = self.indices.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+
+        // 2. 빈 indices → no-op
+        if sorted.is_empty() {
+            *self.snapshot.lock().unwrap() = Some(vec![]);
+            return Ok(());
+        }
+
+        // 3. 범위 검증 (원자성: 하나라도 범위 초과 시 전체 취소)
+        let len = doc.pages.len();
+        for &i in &sorted {
+            if i >= len {
+                return Err(CommandError::ExecutionFailed(format!(
+                    "page index out of bounds: {i} (document has {len} pages)"
+                )));
+            }
+        }
+
+        // 4. 역순 제거: 내림차순 정렬된 인덱스로 remove — Move 시맨틱스, clone 없음
+        let mut sorted_desc = sorted.clone();
+        sorted_desc.sort_unstable_by(|a, b| b.cmp(a));
+
+        let mut removed: Vec<(usize, Page)> = sorted_desc
+            .iter()
+            .map(|&i| (i, doc.pages.remove(i)))
+            .collect();
+
+        // 오름차순 재정렬 (undo 시 insert 순서 보장)
+        removed.sort_by_key(|&(i, _)| i);
+
+        *self.snapshot.lock().unwrap() = Some(removed);
+
+        // 5. 남은 페이지 index 재정렬
+        for (i, page) in doc.pages.iter_mut().enumerate() {
+            page.index = i;
+        }
+
+        Ok(())
+    }
+
+    fn undo(&self, doc: &mut Document) -> Result<(), CommandError> {
+        // 1. snapshot.take() — None이면 execute 전 undo 호출 오류
+        let snapshot =
+            self.snapshot.lock().unwrap().take().ok_or_else(|| {
+                CommandError::UndoFailed("undo called before execute".to_string())
+            })?;
+
+        // 2. 오름차순으로 삽입 (original_index 순서대로 삽입해야 올바른 위치에 들어감)
+        for (original_index, page) in snapshot {
+            doc.pages.insert(original_index, page);
+        }
+
+        // 3. 전체 페이지 index 재정렬
+        for (i, page) in doc.pages.iter_mut().enumerate() {
+            page.index = i;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rpdf_core::types::document::{Document, Page};
+
+    use super::*;
+    use crate::commands::CommandStack;
+
+    fn make_doc(pages: usize, rotations: &[i32]) -> Document {
+        let page_vec = (0..pages)
+            .map(|i| Page {
+                index: i,
+                content: vec![],
+                resources: None,
+                media_box: None,
+                crop_box: None,
+                rotation: rotations.get(i).copied().unwrap_or(0),
+            })
+            .collect();
+        Document {
+            pages: page_vec,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn delete_single_page() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![1]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 2);
+        assert_eq!(doc.pages[0].index, 0);
+        assert_eq!(doc.pages[1].index, 1);
+    }
+
+    #[test]
+    fn delete_multiple_pages() {
+        let mut doc = make_doc(5, &[]);
+        let cmd = DeletePagesCommand::new(vec![1, 3]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+    }
+
+    #[test]
+    fn delete_first_page() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![0]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 2);
+        assert_eq!(doc.pages[0].index, 0);
+    }
+
+    #[test]
+    fn delete_last_page() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![2]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 2);
+        assert_eq!(doc.pages[1].index, 1);
+    }
+
+    #[test]
+    fn undo_restores_deleted_pages() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![1]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 2);
+        cmd.undo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+        assert_eq!(doc.pages[0].index, 0);
+        assert_eq!(doc.pages[1].index, 1);
+        assert_eq!(doc.pages[2].index, 2);
+    }
+
+    #[test]
+    fn execute_undo_redo_via_stack() {
+        let mut doc = make_doc(3, &[]);
+        let mut stack = CommandStack::new(10);
+
+        stack
+            .execute(Box::new(DeletePagesCommand::new(vec![1])), &mut doc)
+            .unwrap();
+        assert_eq!(doc.pages.len(), 2);
+
+        stack.undo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+
+        stack.redo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 2);
+    }
+
+    #[test]
+    fn page_index_out_of_bounds() {
+        let mut doc = make_doc(2, &[]);
+        let cmd = DeletePagesCommand::new(vec![5]);
+        let err = cmd.execute(&mut doc).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("page index out of bounds"));
+            assert!(msg.contains("document has 2 pages"));
+        }
+    }
+
+    #[test]
+    fn duplicate_indices_deduplicated() {
+        let mut doc = make_doc(4, &[]);
+        let cmd = DeletePagesCommand::new(vec![1, 1, 2]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 2);
+    }
+
+    #[test]
+    fn empty_indices_is_noop() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+    }
+
+    #[test]
+    fn delete_all_pages() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![0, 1, 2]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 0);
+        cmd.undo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+        for i in 0..3 {
+            assert_eq!(doc.pages[i].index, i);
+        }
+    }
+
+    #[test]
+    fn undo_before_execute_fails() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![0]);
+        let err = cmd.undo(&mut doc).unwrap_err();
+        assert!(matches!(err, CommandError::UndoFailed(_)));
+        if let CommandError::UndoFailed(msg) = err {
+            assert!(msg.contains("undo called before execute"));
+        }
+    }
+
+    #[test]
+    fn page_indices_consistent_after_execute() {
+        let mut doc = make_doc(5, &[]);
+        let cmd = DeletePagesCommand::new(vec![1, 3]);
+        cmd.execute(&mut doc).unwrap();
+        for (i, page) in doc.pages.iter().enumerate() {
+            assert_eq!(page.index, i);
+        }
+    }
+
+    #[test]
+    fn page_indices_consistent_after_undo() {
+        let mut doc = make_doc(5, &[]);
+        let cmd = DeletePagesCommand::new(vec![1, 3]);
+        cmd.execute(&mut doc).unwrap();
+        cmd.undo(&mut doc).unwrap();
+        for (i, page) in doc.pages.iter().enumerate() {
+            assert_eq!(page.index, i);
+        }
+    }
+
+    #[test]
+    fn partial_out_of_bounds_is_atomic() {
+        let mut doc = make_doc(2, &[]);
+        let cmd = DeletePagesCommand::new(vec![0, 5]);
+        let err = cmd.execute(&mut doc).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        // doc 변경 없음 (원자성 보장)
+        assert_eq!(doc.pages.len(), 2);
+        assert_eq!(doc.pages[0].index, 0);
+        assert_eq!(doc.pages[1].index, 1);
+    }
+
+    #[test]
+    fn double_execute_fails() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = DeletePagesCommand::new(vec![1]);
+        cmd.execute(&mut doc).unwrap();
+        let err = cmd.execute(&mut doc).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("already executed"));
+        }
+    }
+}

--- a/crates/rpdf-edit/src/commands/mod.rs
+++ b/crates/rpdf-edit/src/commands/mod.rs
@@ -1,8 +1,10 @@
+mod delete;
 mod error;
 mod rotate;
 mod stack;
 mod traits;
 
+pub use delete::DeletePagesCommand;
 pub use error::CommandError;
 pub use rotate::RotatePageCommand;
 pub use stack::CommandStack;

--- a/mydocs/plans/task19-delete-pages-command.md
+++ b/mydocs/plans/task19-delete-pages-command.md
@@ -1,0 +1,217 @@
+# Task #19: DeletePagesCommand 구현
+
+**이슈**: #36  
+**브랜치**: `local/task19`  
+**마일스톤**: v0.3 — 편집 커맨드  
+**선행 조건**: Task #18 완료 (`RotatePageCommand`)
+
+---
+
+## 목표
+
+`rpdf-edit` 크레이트에 `DeletePagesCommand`를 추가한다.  
+지정한 페이지 인덱스 목록을 Document에서 제거하고, Undo 시 원래 순서대로 복원한다.
+
+---
+
+## 설계 결정
+
+### 위치
+
+`crates/rpdf-edit/src/commands/delete.rs` 신규 파일.  
+`mod.rs`에서 `pub mod delete; pub use delete::DeletePagesCommand;` 추가.
+
+### DeletePagesCommand 구조체
+
+```rust
+pub struct DeletePagesCommand {
+    indices: Vec<usize>,
+    snapshot: Mutex<Option<Vec<(usize, Page)>>>,
+}
+```
+
+- `indices`: 삭제할 0-based 페이지 인덱스 목록. execute 시 중복 제거 + 정렬 처리.
+- `snapshot`: execute 시 `(original_index, Page 클론)` 쌍을 저장. undo 시 복원에 사용.  
+  `Mutex<Option<...>>`으로 `Command: Send + Sync` 경계 충족. `None`이면 execute 없이 undo 호출 → `UndoFailed` 반환.
+
+**생성자:**
+```rust
+pub fn new(indices: Vec<usize>) -> Self {
+    Self { indices, snapshot: Mutex::new(None) }
+}
+```
+
+### execute 로직
+
+```rust
+fn execute(&self, doc: &mut Document) -> Result<(), CommandError> {
+    // 0. 이중 실행 방어: snapshot이 Some이면 → ExecutionFailed("DeletePagesCommand already executed")
+    // 1. indices.sort_unstable(); indices.dedup(); (sort 먼저 — dedup은 인접 중복만 제거)
+    // 2. 빈 indices → *self.snapshot.lock().unwrap() = Some(vec![]) 후 Ok 반환 (no-op)
+    // 3. 범위 검증: any index >= doc.pages.len() →
+    //    ExecutionFailed("page index out of bounds: {i} (document has {len} pages)")
+    // 4. Move 시맨틱스: sorted_desc.iter().map(|&i| (i, doc.pages.remove(i))).collect()
+    //    → sort_by_key ascending → *self.snapshot.lock().unwrap() = Some(snapshot)
+    //    (clone() 없음 — remove()가 Page 소유권 반환)
+    // 5. 남은 페이지 index 필드 재정렬: doc.pages[i].index = i (for all i)
+}
+```
+
+**역순 제거 이유**: 오름차순 인덱스를 정순으로 제거하면 뒤 인덱스가 shift된다.  
+역순(내림차순)으로 제거하면 앞쪽 인덱스가 유효하게 유지된다.
+
+### undo 로직
+
+```rust
+fn undo(&self, doc: &mut Document) -> Result<(), CommandError> {
+    // 1. snapshot.take(): self.snapshot.lock().unwrap().take()
+    //    None → UndoFailed("undo called before execute")
+    //    (take()로 소유권 이동 + snapshot을 None으로 리셋 — 이중 undo 방지)
+    // 2. snapshot 엔트리를 original_index 오름차순으로 순회:
+    //    doc.pages.insert(original_index, page)  (by value, clone() 없음)
+    // 3. 전체 페이지 index 필드 재정렬: doc.pages[i].index = i (for all i)
+}
+```
+
+**오름차순 삽입 이유**: 인덱스 1과 3을 복원할 때, 1 먼저 삽입하면 2(기존)가 올바른 위치에 있고, 3 삽입 시 정확히 원래 자리에 들어간다.
+
+### Page.index 재정렬 정책
+
+execute 후와 undo 후 모두 `doc.pages[i].index = i`로 전체 재정렬한다.  
+`Page.index`는 "현재 문서에서의 위치"를 나타내므로, 페이지 목록이 바뀔 때마다 유효해야 한다.
+
+### 에러 처리
+
+| 조건 | 에러 변형 |
+|------|---------|
+| `any index >= doc.pages.len()` | `CommandError::ExecutionFailed("page index out of bounds: {i} (document has {len} pages)")` |
+| `indices` 비어있음 | 성공 (no-op). `snapshot = Some(vec![])` |
+| execute 없이 undo 호출 (snapshot None) | `CommandError::UndoFailed("undo called before execute")` |
+| snapshot이 Some인 상태에서 execute 재호출 | `CommandError::ExecutionFailed("DeletePagesCommand already executed")` |
+
+> 중복 인덱스는 에러가 아니라 silent dedup으로 처리한다 (사용자 편의).  
+> 전체 페이지 삭제(`indices`가 모든 인덱스 포함)는 허용한다 — 빈 Document가 결과.
+
+---
+
+## 파일 구조 변경
+
+```
+crates/rpdf-edit/src/commands/
+├── mod.rs      (delete 모듈 추가)
+├── delete.rs   ← 신규
+├── error.rs    (변경 없음)
+├── rotate.rs   (변경 없음)
+├── stack.rs    (변경 없음)
+└── traits.rs   (변경 없음)
+```
+
+`mod.rs` 변경:
+```rust
+mod delete;   // 신규
+mod error;
+mod rotate;
+mod stack;
+mod traits;
+
+pub use delete::DeletePagesCommand;   // 신규
+pub use error::CommandError;
+pub use rotate::RotatePageCommand;
+pub use stack::CommandStack;
+pub use traits::{Command, Query};
+```
+
+---
+
+## 테스트 전략
+
+위치: `delete.rs` 하단 `#[cfg(test)] mod tests {}`  
+테스트 헬퍼: `RotatePageCommand`와 동일한 `make_doc(pages: usize, rotations: &[i32])` 재작성.
+
+| # | 테스트명 | 검증 내용 |
+|---|---------|---------|
+| 1 | `delete_single_page` | 3-page doc, index 1 삭제 → 2페이지, 나머지 index 재정렬 |
+| 2 | `delete_multiple_pages` | 5-page doc, [1, 3] 삭제 → 3페이지 |
+| 3 | `delete_first_page` | index 0 삭제 → 앞 페이지 제거 |
+| 4 | `delete_last_page` | 마지막 index 삭제 |
+| 5 | `undo_restores_deleted_pages` | execute → undo → 원래 페이지 수·순서 복원 |
+| 6 | `execute_undo_redo_via_stack` | CommandStack 통해 execute → undo → redo 라운드트립 |
+| 7 | `page_index_out_of_bounds` | 존재하지 않는 index → ExecutionFailed |
+| 8 | `duplicate_indices_deduplicated` | [1, 1, 2] → [1, 2] 처리, 2페이지 삭제 |
+| 9 | `empty_indices_is_noop` | [] 삭제 → 변경 없음, undo 후에도 동일 |
+| 10 | `delete_all_pages` | 전체 삭제 → 빈 Document, undo 후 복원 |
+| 11 | `undo_before_execute_fails` | execute 없이 undo → UndoFailed("undo called before execute") |
+| 12 | `page_indices_consistent_after_execute` | 삭제 후 남은 pages의 index 필드가 0,1,2... |
+| 13 | `page_indices_consistent_after_undo` | undo 후 모든 pages의 index 필드가 0,1,2... |
+| 14 | `partial_out_of_bounds_is_atomic` | new(vec![0, 5]) on 2-page doc → ExecutionFailed, doc 변경 없음 (원자성 보장) |
+| 15 | `double_execute_fails` | execute() 후 동일 인스턴스에 execute() 재호출 → ExecutionFailed("already executed") |
+
+---
+
+## 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| `indices = []` | no-op. `snapshot = Some(vec![])`. undo도 no-op |
+| 중복 인덱스 `[2, 2, 2]` | dedup → `[2]`, 페이지 1개 삭제 |
+| 전체 페이지 삭제 | 허용. `doc.pages = []`. undo 후 복원 |
+| 1페이지 문서에서 index 0 삭제 | 허용. 빈 Document |
+| out-of-bounds 인덱스 하나라도 포함 | 전체 취소. 아무 페이지도 삭제 안 함 |
+
+---
+
+## NOT in scope
+
+| 항목 | 이유 |
+|------|------|
+| PDF 내부 참조 정리 (`/Dests`, `/Outlines`, `/Annots`) | 삭제된 페이지를 향하는 링크·북마크는 dangling 상태가 됨. Issue #22 Serializer 구현 시 처리 |
+| O(N) 파티션 알고리즘 최적화 | YAGNI. 수백 페이지 규모에서 O(k·N)이면 충분. 성능 문제 발생 시 TODO |
+| PageId 기반 안정적 참조 | v0.3 범위 밖 (Task #17 설계에서 DEFER 결정) |
+
+## 의존성
+
+- `rpdf_core::types::document::{Document, Page}` — `Page: Clone` 필요 (기존 `#[derive(Clone)]` 확인됨)
+- `rpdf_edit::commands::{Command, CommandError, CommandStack}` — 기존
+- `std::sync::Mutex` — 표준 라이브러리
+
+신규 외부 의존성 없음.
+
+---
+
+## 체크포인트
+
+| 체크포인트 | 내용 | 완료 조건 |
+|-----------|------|-----------|
+| CP-1 | `delete.rs` 생성 + `mod.rs` 등록 | `cargo build -p rpdf-edit` 통과 |
+| CP-2 | `execute` + `undo` 구현 | `cargo build -p rpdf-edit` 통과 |
+| CP-3 | 15개 단위 테스트 | `cargo test -p rpdf-edit` 통과 |
+| CP-4 | 전체 품질 게이트 | `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` |
+
+---
+
+## 완료 기준
+
+1. `DeletePagesCommand`가 `rpdf_edit::commands::DeletePagesCommand`로 공개 API 노출됨
+2. execute/undo 대칭성 보장 (`CommandStack` 라운드트립 테스트)
+3. 역순 제거 + 오름차순 삽입으로 올바른 페이지 순서 복원
+4. `Page.index` 재정렬 (`execute` 후, `undo` 후 모두)
+5. 15개 단위 테스트 통과
+6. `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` 통과
+7. 공개 API `///` 문서 주석 + `# Examples` 섹션
+8. 에러 메시지에 현재 상태 포함 (`has {len} pages`)
+9. 이중 execute 방어 (`"DeletePagesCommand already executed"`)
+10. Move 시맨틱스 — clone() 없이 `Vec::remove()` 반환값 직접 snapshot 저장
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Outside Voice | Gemini CLI | Independent 2nd opinion | 1 | issues_found | 5 points: 2 adopted (Move+guard), 1 deferred (O(n)), 1 NOT in scope (refs), 1 false positive |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | **CLEAR** | 3 issues found → all resolved (sort/dedup, test 14, test 15) |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | N/A (no UI) |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**VERDICT: ENG REVIEW CLEAR — 구현 시작 가능.**

--- a/mydocs/working/task19-done.md
+++ b/mydocs/working/task19-done.md
@@ -1,0 +1,101 @@
+# Task #19 완료 보고서: DeletePagesCommand 구현
+
+**이슈**: #36  
+**브랜치**: `local/task19`  
+**마일스톤**: v0.3 — 편집 커맨드  
+**완료일**: 2026-05-04
+
+---
+
+## 완료 체크리스트
+
+- [x] `crates/rpdf-edit/src/commands/delete.rs` 신규 파일 생성
+- [x] `mod.rs`에 `mod delete` + `pub use delete::DeletePagesCommand` 추가
+- [x] `DeletePagesCommand::new(indices)` 공개 생성자 + `///` 문서 주석 + `# Examples` doctest
+- [x] `execute` 구현: 이중실행 방어 → sort+dedup → 빈 인덱스 no-op → 범위 검증(원자성) → 역순 제거(Move 시맨틱스) → 오름차순 snapshot 저장 → index 재정렬
+- [x] `undo` 구현: `snapshot.take()`(이중 undo 방지) → 오름차순 insert 복원 → index 재정렬
+- [x] 15개 단위 테스트 통과
+- [x] `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` 전체 통과
+
+---
+
+## 구현 내용
+
+### 파일 구조 변경
+
+```
+crates/rpdf-edit/src/commands/
+├── mod.rs      (delete 모듈 등록 + pub use 추가)
+├── delete.rs   ← 신규
+├── error.rs    (변경 없음)
+├── rotate.rs   (변경 없음)
+├── stack.rs    (변경 없음)
+└── traits.rs   (변경 없음)
+```
+
+### 주요 설계 결정
+
+1. **`Mutex<Option<Vec<(usize, Page)>>>`**: `Command: Send + Sync` 경계 충족. `None` 센티넬로 execute 없이 undo 호출 시 `UndoFailed("undo called before execute")` 반환. `take()`으로 이중 undo 방지.
+
+2. **역순 제거 + 오름차순 복원**:
+   - execute: `sorted_desc`로 내림차순 정렬 후 `doc.pages.remove(i)` — 앞쪽 인덱스 shift 방지
+   - snapshot을 `sort_by_key(|&(i, _)| i)`로 오름차순 재정렬 저장
+   - undo: 오름차순으로 `doc.pages.insert(original_index, page)` — 정확한 원래 위치 복원
+
+3. **Move 시맨틱스**: `doc.pages.remove(i)` 반환값(소유권)을 직접 snapshot에 저장 — `Page::clone()` 없음.
+
+4. **이중 실행 방어**: execute 진입 시 `snapshot.is_some()` 체크 → `ExecutionFailed("DeletePagesCommand already executed")`.
+
+5. **원자성 보장**: 범위 검증이 remove 이전에 완전 완료. 인덱스 하나라도 OOB이면 doc 변경 없이 전체 취소.
+
+6. **에러 메시지에 현재 상태 포함**: `"page index out of bounds: {i} (document has {len} pages)"`.
+
+---
+
+## 품질 게이트
+
+| 명령 | 결과 |
+|------|------|
+| `cargo test -p rpdf-edit` | 35/35 단위 테스트 + 2개 doctest 통과 |
+| `cargo clippy -p rpdf-edit -- -D warnings` | 경고 없음 |
+| `cargo fmt --check` | 통과 |
+
+---
+
+## 테스트 커버리지
+
+| # | 테스트명 | 검증 |
+|---|---------|------|
+| 1 | `delete_single_page` | 3-page doc, index 1 삭제 → 2페이지, index 재정렬 |
+| 2 | `delete_multiple_pages` | 5-page doc, [1, 3] 삭제 → 3페이지 |
+| 3 | `delete_first_page` | index 0 삭제 → 앞 페이지 제거 |
+| 4 | `delete_last_page` | 마지막 index 삭제 |
+| 5 | `undo_restores_deleted_pages` | execute → undo → 원래 페이지 수·순서 복원 |
+| 6 | `execute_undo_redo_via_stack` | CommandStack 라운드트립 |
+| 7 | `page_index_out_of_bounds` | OOB index → ExecutionFailed |
+| 8 | `duplicate_indices_deduplicated` | [1, 1, 2] → 2페이지 삭제 |
+| 9 | `empty_indices_is_noop` | [] → 변경 없음 |
+| 10 | `delete_all_pages` | 전체 삭제 → 빈 Document, undo 후 복원 |
+| 11 | `undo_before_execute_fails` | UndoFailed("undo called before execute") |
+| 12 | `page_indices_consistent_after_execute` | 삭제 후 남은 pages의 index 0,1,2... |
+| 13 | `page_indices_consistent_after_undo` | undo 후 모든 pages의 index 0,1,2... |
+| 14 | `partial_out_of_bounds_is_atomic` | vec![0, 5] on 2-page doc → ExecutionFailed, doc 변경 없음 |
+| 15 | `double_execute_fails` | execute() 재호출 → ExecutionFailed("already executed") |
+
+---
+
+## 회고 분류 표
+
+| # | 항목 요약 | 카테고리 | 판단 근거 |
+|---|---------|---------|---------|
+| 1 | `sort_unstable() → dedup()` 순서 — dedup은 인접 중복만 제거 | C: 스킵 | CLAUDE.md 설계 원칙에서 이미 다루는 Rust 관용구 |
+| 2 | 역순 제거 + 오름차순 복원 패턴 | C: 완료 보고서 메모 | 계획서에 충분히 설명됨, 별도 CLAUDE.md 규칙 불필요 |
+| 3 | `snapshot.take()`로 이중 undo 방지 + `is_some()`으로 이중 execute 방지 | C: 스킵 | `Mutex<Option<T>>` 패턴은 CLAUDE.md에 이미 기록됨 |
+
+모든 항목이 C(스킵) — CLAUDE.md 추가나 트러블슈팅 문서 생성 없이 완료.
+
+---
+
+## 다음 작업
+
+Task #20: `InsertPageCommand` 또는 v0.3 다음 편집 커맨드 (마일스톤 확인 필요).


### PR DESCRIPTION
## Summary

- `crates/rpdf-edit/src/commands/delete.rs` 신규 — `DeletePagesCommand` 구조체, `Command` 트레이트 구현
- 역순 제거(내림차순 index) + 오름차순 복원으로 페이지 순서 정확성 보장
- Move 시맨틱스: `Vec::remove()` 반환값 직접 snapshot 저장 (`clone()` 없음)
- 이중 execute 방어(`snapshot.is_some()`) + 이중 undo 방지(`snapshot.take()`)
- `mod.rs`: `mod delete` + `pub use delete::DeletePagesCommand` 추가

## Test plan

- [x] `delete_single_page` — 3-page doc, index 1 삭제 → 2페이지
- [x] `delete_multiple_pages` — [1, 3] 삭제 → 3페이지
- [x] `delete_first_page` / `delete_last_page`
- [x] `undo_restores_deleted_pages` — 원래 페이지 수·순서 복원
- [x] `execute_undo_redo_via_stack` — CommandStack 라운드트립
- [x] `page_index_out_of_bounds` — ExecutionFailed
- [x] `duplicate_indices_deduplicated` — [1, 1, 2] → 2페이지 삭제
- [x] `empty_indices_is_noop`
- [x] `delete_all_pages` — 빈 Document, undo 후 복원
- [x] `undo_before_execute_fails`
- [x] `page_indices_consistent_after_execute` / `_after_undo`
- [x] `partial_out_of_bounds_is_atomic` — 원자성 보장
- [x] `double_execute_fails`
- [x] `cargo test -p rpdf-edit` (35 unit + 2 doctest 통과)
- [x] `cargo clippy -p rpdf-edit -- -D warnings` (경고 없음)
- [x] `cargo fmt --check` (통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)