### PR TITLE
Task #20: MergeCommand 구현

### DIFF
--- a/crates/rpdf-edit/src/commands/delete.rs
+++ b/crates/rpdf-edit/src/commands/delete.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 
 use rpdf_core::types::document::{Document, Page};
 
-use crate::commands::{Command, CommandError};
+use crate::commands::{Command, CommandError, reindex_pages};
 
 /// 지정한 페이지 인덱스 목록을 Document에서 제거하는 커맨드.
 ///
@@ -83,9 +83,7 @@ impl Command for DeletePagesCommand {
         *self.snapshot.lock().unwrap() = Some(removed);
 
         // 5. 남은 페이지 index 재정렬
-        for (i, page) in doc.pages.iter_mut().enumerate() {
-            page.index = i;
-        }
+        reindex_pages(&mut doc.pages);
 
         Ok(())
     }
@@ -103,9 +101,7 @@ impl Command for DeletePagesCommand {
         }
 
         // 3. 전체 페이지 index 재정렬
-        for (i, page) in doc.pages.iter_mut().enumerate() {
-            page.index = i;
-        }
+        reindex_pages(&mut doc.pages);
 
         Ok(())
     }

--- a/crates/rpdf-edit/src/commands/merge.rs
+++ b/crates/rpdf-edit/src/commands/merge.rs
@@ -1,0 +1,286 @@
+use std::sync::Mutex;
+
+use rpdf_core::types::document::Document;
+
+use crate::commands::{Command, CommandError, reindex_pages};
+
+/// 하나 이상의 소스 Document 페이지를 대상 Document 뒤에 순서대로 추가하는 커맨드.
+///
+/// 소스 내 페이지 순서와 소스 간 순서 모두 보존된다.
+/// Undo 시 추가된 페이지를 제거해 원래 상태로 복원한다.
+///
+/// # Ownership
+///
+/// sources의 소유권을 커맨드가 가져감.
+/// 호출자가 재사용하려면 `doc.clone()` 후 전달.
+///
+/// # Examples
+///
+/// ```rust
+/// use rpdf_edit::commands::MergeCommand;
+/// use rpdf_core::types::document::Document;
+///
+/// let source = Document { pages: vec![], metadata: None };
+/// let cmd = MergeCommand::new(vec![source]);
+/// ```
+pub struct MergeCommand {
+    sources: Vec<Document>,
+    snapshot: Mutex<Option<usize>>,
+}
+
+impl MergeCommand {
+    /// 새 `MergeCommand`를 생성한다.
+    ///
+    /// # Arguments
+    /// * `sources` - 합산할 소스 Document 목록. 소유권을 커맨드가 가져감.
+    ///   호출자가 재사용하려면 `doc.clone()` 후 전달.
+    pub fn new(sources: Vec<Document>) -> Self {
+        Self {
+            sources,
+            snapshot: Mutex::new(None),
+        }
+    }
+}
+
+impl Command for MergeCommand {
+    fn name(&self) -> &'static str {
+        "MergeCommand"
+    }
+
+    fn execute(&self, doc: &mut Document) -> Result<(), CommandError> {
+        // 0. 이중 실행 방어
+        if self.snapshot.lock().unwrap().is_some() {
+            return Err(CommandError::ExecutionFailed(
+                "MergeCommand already executed".to_string(),
+            ));
+        }
+
+        // 1. execute 전 페이지 수 저장
+        let original_len = doc.pages.len();
+
+        // 2. sources 비어 있으면 no-op
+        if self.sources.is_empty() {
+            *self.snapshot.lock().unwrap() = Some(original_len);
+            return Ok(());
+        }
+
+        // 3. 각 source document의 pages를 순서대로 clone + append
+        for source in &self.sources {
+            doc.pages.extend(source.pages.iter().cloned());
+        }
+
+        // 4. 전체 페이지 index 재정렬
+        reindex_pages(&mut doc.pages);
+
+        // 5. snapshot 저장
+        *self.snapshot.lock().unwrap() = Some(original_len);
+
+        Ok(())
+    }
+
+    fn undo(&self, doc: &mut Document) -> Result<(), CommandError> {
+        // 1. snapshot.take() — None이면 execute 전 undo 호출 오류
+        let original_len =
+            self.snapshot.lock().unwrap().take().ok_or_else(|| {
+                CommandError::UndoFailed("undo called before execute".to_string())
+            })?;
+
+        // 2. 추가된 페이지 제거
+        doc.pages.truncate(original_len);
+
+        // 3. 전체 페이지 index 재정렬
+        reindex_pages(&mut doc.pages);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rpdf_core::types::document::{Document, Page};
+
+    use super::*;
+    use crate::commands::CommandStack;
+
+    fn make_doc(pages: usize, rotations: &[i32]) -> Document {
+        let page_vec = (0..pages)
+            .map(|i| Page {
+                index: i,
+                content: vec![],
+                resources: None,
+                media_box: None,
+                crop_box: None,
+                rotation: rotations.get(i).copied().unwrap_or(0),
+            })
+            .collect();
+        Document {
+            pages: page_vec,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn merge_single_source() {
+        let mut doc = make_doc(3, &[]);
+        let source = make_doc(2, &[]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 5);
+    }
+
+    #[test]
+    fn merge_multiple_sources() {
+        let mut doc = make_doc(2, &[]);
+        let s1 = make_doc(3, &[10, 11, 12]);
+        let s2 = make_doc(1, &[20]);
+        let cmd = MergeCommand::new(vec![s1, s2]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 6);
+        // 소스 간 순서: s1 페이지(index 2,3,4) → s2 페이지(index 5)
+        assert_eq!(doc.pages[2].rotation, 10);
+        assert_eq!(doc.pages[4].rotation, 12);
+        assert_eq!(doc.pages[5].rotation, 20);
+    }
+
+    #[test]
+    fn merge_empty_sources_is_noop() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = MergeCommand::new(vec![]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+    }
+
+    #[test]
+    fn merge_empty_source_document() {
+        let mut doc = make_doc(3, &[]);
+        let source = make_doc(0, &[]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+    }
+
+    #[test]
+    fn merge_into_empty_target() {
+        let mut doc = make_doc(0, &[]);
+        let source = make_doc(3, &[]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+        cmd.undo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 0);
+    }
+
+    #[test]
+    fn undo_restores_original_pages() {
+        let mut doc = make_doc(3, &[]);
+        let source = make_doc(2, &[]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 5);
+        cmd.undo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+        for i in 0..3 {
+            assert_eq!(doc.pages[i].index, i);
+        }
+    }
+
+    #[test]
+    fn execute_undo_redo_via_stack() {
+        let mut doc = make_doc(3, &[]);
+        let source = make_doc(2, &[]);
+        let mut stack = CommandStack::new(10);
+
+        stack
+            .execute(Box::new(MergeCommand::new(vec![source])), &mut doc)
+            .unwrap();
+        assert_eq!(doc.pages.len(), 5);
+
+        stack.undo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 3);
+
+        stack.redo(&mut doc).unwrap();
+        assert_eq!(doc.pages.len(), 5);
+    }
+
+    #[test]
+    fn page_indices_consistent_after_merge() {
+        let mut doc = make_doc(3, &[]);
+        let source = make_doc(2, &[]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+        for (i, page) in doc.pages.iter().enumerate() {
+            assert_eq!(page.index, i);
+        }
+    }
+
+    #[test]
+    fn page_indices_consistent_after_undo() {
+        let mut doc = make_doc(3, &[]);
+        let source = make_doc(2, &[]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+        cmd.undo(&mut doc).unwrap();
+        for (i, page) in doc.pages.iter().enumerate() {
+            assert_eq!(page.index, i);
+        }
+    }
+
+    #[test]
+    fn double_execute_fails() {
+        let mut doc = make_doc(3, &[]);
+        let source = make_doc(2, &[]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+        let err = cmd.execute(&mut doc).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("already executed"));
+        }
+    }
+
+    #[test]
+    fn undo_before_execute_fails() {
+        let mut doc = make_doc(3, &[]);
+        let cmd = MergeCommand::new(vec![]);
+        let err = cmd.undo(&mut doc).unwrap_err();
+        assert!(matches!(err, CommandError::UndoFailed(_)));
+        if let CommandError::UndoFailed(msg) = err {
+            assert!(msg.contains("undo called before execute"));
+        }
+    }
+
+    #[test]
+    fn merge_preserves_page_content() {
+        let mut doc = make_doc(1, &[90]);
+        doc.pages[0].media_box = Some([0.0, 0.0, 595.0, 842.0]);
+
+        let mut source = make_doc(1, &[180]);
+        source.pages[0].media_box = Some([0.0, 0.0, 210.0, 297.0]);
+
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+
+        assert_eq!(doc.pages[0].rotation, 90);
+        assert_eq!(doc.pages[0].media_box, Some([0.0, 0.0, 595.0, 842.0]));
+        assert_eq!(doc.pages[1].rotation, 180);
+        assert_eq!(doc.pages[1].media_box, Some([0.0, 0.0, 210.0, 297.0]));
+    }
+
+    #[test]
+    fn merge_source_page_order_preserved() {
+        let mut doc = make_doc(2, &[]);
+        let source = make_doc(3, &[90, 180, 270]);
+        let cmd = MergeCommand::new(vec![source]);
+        cmd.execute(&mut doc).unwrap();
+
+        assert_eq!(doc.pages.len(), 5);
+        // 소스 페이지 순서: rotation 90, 180, 270
+        assert_eq!(doc.pages[2].rotation, 90);
+        assert_eq!(doc.pages[3].rotation, 180);
+        assert_eq!(doc.pages[4].rotation, 270);
+        // index도 올바르게 재정렬됨
+        assert_eq!(doc.pages[2].index, 2);
+        assert_eq!(doc.pages[3].index, 3);
+        assert_eq!(doc.pages[4].index, 4);
+    }
+}

--- a/crates/rpdf-edit/src/commands/mod.rs
+++ b/crates/rpdf-edit/src/commands/mod.rs
@@ -1,11 +1,22 @@
 mod delete;
 mod error;
+mod merge;
 mod rotate;
 mod stack;
 mod traits;
 
 pub use delete::DeletePagesCommand;
 pub use error::CommandError;
+pub use merge::MergeCommand;
 pub use rotate::RotatePageCommand;
 pub use stack::CommandStack;
 pub use traits::{Command, Query};
+
+use rpdf_core::types::document::Page;
+
+/// 페이지 목록의 index 필드를 현재 위치(0-based)에 맞게 재정렬한다.
+pub(crate) fn reindex_pages(pages: &mut [Page]) {
+    for (i, page) in pages.iter_mut().enumerate() {
+        page.index = i;
+    }
+}

--- a/mydocs/plans/task20-merge-command.md
+++ b/mydocs/plans/task20-merge-command.md
@@ -1,0 +1,256 @@
+# Task #20: MergeCommand 구현
+
+**이슈**: #38  
+**브랜치**: `local/task20`  
+**마일스톤**: v0.3 — 편집 커맨드  
+**선행 조건**: Task #19 완료 (`DeletePagesCommand`)
+
+---
+
+## 목표
+
+`rpdf-edit` 크레이트에 `MergeCommand`를 추가한다.  
+하나 이상의 소스 Document 페이지를 대상 Document 뒤에 순서대로 추가하고,  
+Undo 시 추가된 페이지를 제거해 원래 상태로 복원한다.
+
+---
+
+## 설계 결정
+
+### IR 수준 단순 합산 방침
+
+현재 `Page.resources`는 상속이 해결된(materialized) 자기완결 딕셔너리다.  
+서로 다른 Document에서 온 두 Page는 별개의 `resources: Option<PdfDict>`를 가지므로,  
+IR 수준에서 리소스 이름 충돌이 발생하지 않는다.
+
+리소스 prefix 재작성(중복 폰트/이미지 이름 처리)은  
+**Task #22 Serializer**가 PDF 바이트를 생성할 때의 문제다.  
+MergeCommand는 IR 수준에서 단순 페이지 연결만 담당한다.
+
+### 위치
+
+`crates/rpdf-edit/src/commands/merge.rs` 신규 파일.  
+`mod.rs`에서 `pub mod merge; pub use merge::MergeCommand;` 추가.
+
+### MergeCommand 구조체
+
+```rust
+pub struct MergeCommand {
+    sources: Vec<Document>,
+    snapshot: Mutex<Option<usize>>,
+}
+```
+
+- `sources`: 합산할 소스 Document 목록. execute 시 각 Document의 pages를 순서대로 클론해 대상 doc에 append.
+- `snapshot`: execute 전 `doc.pages.len()`을 저장. undo 시 truncate 기준.  
+  `Mutex<Option<usize>>`으로 `Command: Send + Sync` 경계 충족.  
+  `None`이면 execute 없이 undo 호출 → `UndoFailed` 반환.
+
+**생성자:**
+```rust
+pub fn new(sources: Vec<Document>) -> Self {
+    Self { sources, snapshot: Mutex::new(None) }
+}
+```
+
+### execute 로직
+
+```rust
+fn execute(&self, doc: &mut Document) -> Result<(), CommandError> {
+    // 0. 이중 실행 방어: snapshot이 Some이면 → ExecutionFailed("MergeCommand already executed")
+    // 1. original_len = doc.pages.len() 저장
+    // 2. sources가 비어 있으면 → *self.snapshot.lock().unwrap() = Some(original_len) 후 Ok (no-op)
+    // 3. 각 source document의 pages를 순서대로 clone + append:
+    //    for source in &self.sources { doc.pages.extend(source.pages.iter().cloned()); }
+    // 4. 전체 index 재정렬: doc.pages[i].index = i (for all i)
+    // 5. *self.snapshot.lock().unwrap() = Some(original_len)
+}
+```
+
+**source.pages 순서 보장**: `sources` 벡터 순서대로 각 Document의 pages[0..n-1]이 추가된다.  
+소스 내 페이지 순서, 소스 간 순서 모두 보존된다.
+
+### undo 로직
+
+```rust
+fn undo(&self, doc: &mut Document) -> Result<(), CommandError> {
+    // 1. snapshot.take(): self.snapshot.lock().unwrap().take()
+    //    None → UndoFailed("undo called before execute")
+    // 2. doc.pages.truncate(original_len)
+    // 3. 전체 index 재정렬: doc.pages[i].index = i (for all i)
+}
+```
+
+**`truncate` 기반 undo 이유**: append는 항상 뒤에 붙이므로 `truncate(original_len)`만으로 원래 상태 복원 가능.  
+DeletePagesCommand처럼 페이지별 스냅샷이 필요 없다 (`Page` clone 없음, `original_len: usize`만 저장).
+
+### Page.index 재정렬 정책
+
+execute 후와 undo 후 모두 `doc.pages[i].index = i`로 전체 재정렬.
+
+### 메타데이터 처리 방침
+
+대상 Document의 `metadata`는 변경하지 않는다.  
+소스 Document의 metadata는 무시된다.  
+"합쳐진 문서의 메타데이터는 첫 번째 문서(대상)의 것" 정책.
+
+### 에러 처리
+
+| 조건 | 에러 변형 |
+|------|---------|
+| snapshot이 Some인 상태에서 execute 재호출 | `CommandError::ExecutionFailed("MergeCommand already executed")` |
+| execute 없이 undo 호출 (snapshot None) | `CommandError::UndoFailed("undo called before execute")` |
+| sources 비어있음 | 성공 (no-op). `snapshot = Some(original_len)` |
+| source Document가 0페이지 | 해당 source 건너뜀 (no-op for that source). 정상 진행 |
+
+---
+
+## 파일 구조 변경
+
+```
+crates/rpdf-edit/src/commands/
+├── mod.rs      (merge 모듈 추가 + reindex_pages 헬퍼 추가)
+├── delete.rs   (reindex_pages 헬퍼로 교체 — 인라인 루프 제거)
+├── error.rs    (변경 없음)
+├── merge.rs    ← 신규
+├── rotate.rs   (변경 없음)
+├── stack.rs    (변경 없음)
+└── traits.rs   (변경 없음)
+```
+
+### reindex_pages 헬퍼 추출 (DRY)
+
+`mod.rs` 또는 `merge.rs` 상단에 크레이트 전용 헬퍼 함수를 추가한다:
+
+```rust
+pub(crate) fn reindex_pages(pages: &mut [Page]) {
+    for (i, page) in pages.iter_mut().enumerate() {
+        page.index = i;
+    }
+}
+```
+
+- `delete.rs`의 두 인라인 루프를 `reindex_pages(&mut doc.pages)` 호출로 교체
+- `merge.rs`의 두 인라인 루프를 `reindex_pages(&mut doc.pages)` 호출로 교체
+- 위치: `mod.rs`에 `pub(crate) fn reindex_pages` 추가 (모든 command 모듈이 `use super::*`나 `use crate::commands::` 로 접근 가능)
+
+`mod.rs` 변경:
+```rust
+mod delete;
+mod error;
+mod merge;   // 신규
+mod rotate;
+mod stack;
+mod traits;
+
+pub use delete::DeletePagesCommand;
+pub use error::CommandError;
+pub use merge::MergeCommand;   // 신규
+pub use rotate::RotatePageCommand;
+pub use stack::CommandStack;
+pub use traits::{Command, Query};
+
+use rpdf_core::types::document::Page;
+
+/// 페이지 목록의 index 필드를 현재 위치(0-based)에 맞게 재정렬한다.
+pub(crate) fn reindex_pages(pages: &mut [Page]) {
+    for (i, page) in pages.iter_mut().enumerate() {
+        page.index = i;
+    }
+}
+```
+
+---
+
+## 테스트 전략
+
+위치: `merge.rs` 하단 `#[cfg(test)] mod tests {}`  
+테스트 헬퍼: `make_doc(pages: usize, rotations: &[i32]) -> Document` — rotate.rs·delete.rs와 동일.
+
+| # | 테스트명 | 검증 내용 |
+|---|---------|---------|
+| 1 | `merge_single_source` | 3-page target + 2-page source → 5페이지 |
+| 2 | `merge_multiple_sources` | 2-page target + [3-page, 1-page] sources → 6페이지 |
+| 3 | `merge_empty_sources_is_noop` | sources=[] → 변경 없음 |
+| 4 | `merge_empty_source_document` | sources=[0-page doc] → 변경 없음 |
+| 5 | `merge_into_empty_target` | target 0페이지 + 3-page source → 3페이지, **undo 후 0페이지 복원 포함** |
+| 6 | `undo_restores_original_pages` | execute → undo → 원래 페이지 수·순서 복원 |
+| 7 | `execute_undo_redo_via_stack` | CommandStack 통해 execute → undo → redo 라운드트립 |
+| 8 | `page_indices_consistent_after_merge` | merge 후 doc.pages[i].index = i (for all i) |
+| 9 | `page_indices_consistent_after_undo` | undo 후 doc.pages[i].index = i (for all i) |
+| 10 | `double_execute_fails` | execute() 후 재호출 → ExecutionFailed("already executed") |
+| 11 | `undo_before_execute_fails` | execute 없이 undo → UndoFailed("undo called before execute") |
+| 12 | `merge_preserves_page_content` | 합산된 page의 rotation·media_box 등 원본 값 보존 |
+| 13 | `merge_source_page_order_preserved` | 3-page source의 페이지 순서(0,1,2)가 target 뒤에 그대로 유지됨 |
+
+---
+
+## 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| `sources = []` | no-op. `snapshot = Some(original_len)`. undo도 no-op |
+| source Document가 0페이지 | 해당 source 건너뜀. 다른 source는 정상 처리 |
+| target이 0페이지 | 허용. source pages가 index 0부터 시작하게 됨 |
+| 매우 큰 source | no limit. 메모리는 호출자 책임 |
+
+---
+
+## NOT in scope
+
+| 항목 | 이유 |
+|------|------|
+| 리소스 이름 prefix 재작성 | IR 수준 불필요. Serializer(Task #22) 담당 |
+| 소스 metadata 병합 | YAGNI. 단순 정책(target 우선) 적용 |
+| 페이지 삽입 위치 지정 | append-only. SplitInsertCommand 등 별도 Task |
+| 진행 콜백 / 대용량 최적화 | YAGNI |
+
+---
+
+## 의존성
+
+- `rpdf_core::types::document::{Document, Page}` — `Document: Clone`, `Page: Clone` 확인됨
+- `rpdf_edit::commands::{Command, CommandError, CommandStack}` — 기존
+- `std::sync::Mutex` — 표준 라이브러리
+
+신규 외부 의존성 없음.
+
+---
+
+## 체크포인트
+
+| 체크포인트 | 내용 | 완료 조건 |
+|-----------|------|-----------|
+| CP-1 | `merge.rs` 생성 + `mod.rs` 등록 | `cargo build -p rpdf-edit` 통과 |
+| CP-2 | `execute` + `undo` 구현 | `cargo build -p rpdf-edit` 통과 |
+| CP-3 | 13개 단위 테스트 | `cargo test -p rpdf-edit` 통과 |
+| CP-4 | 전체 품질 게이트 | `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` |
+
+---
+
+## 완료 기준
+
+1. `MergeCommand`가 `rpdf_edit::commands::MergeCommand`로 공개 API 노출됨
+2. execute/undo 대칭성 보장 (`CommandStack` 라운드트립 테스트)
+3. 소스 페이지 순서 보존 (소스 내 순서, 소스 간 순서 모두)
+4. `Page.index` 재정렬 (`execute` 후, `undo` 후 모두)
+5. 13개 단위 테스트 통과
+6. `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` 통과
+7. 공개 API `///` 문서 주석 + `# Examples` 섹션
+8. 이중 execute 방어 (`"MergeCommand already executed"`)
+9. `original_len: usize`만 snapshot으로 저장 — Page clone 최소화
+10. `new()` 문서에 소유권 이동 명시: "sources의 소유권을 커맨드가 가져감. 호출자가 재사용하려면 `doc.clone()` 후 전달"
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Outside Voice | Gemini CLI (폴백: Claude subagent) | Independent 2nd opinion | 1 | issues_found | 6 points: 2 resolved (소유권 문서, test #5 확장), 3 false positive (redo, empty slice, delete.rs), 1 confirmed process note |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | **CLEAR** | 2 issues found → all resolved (reindex_pages DRY 추출, test #5 undo 확장) |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | N/A (no UI) |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**VERDICT: ENG REVIEW CLEAR — 구현 시작 가능.**

--- a/mydocs/working/task20-done.md
+++ b/mydocs/working/task20-done.md
@@ -1,0 +1,85 @@
+# Task #20 완료 보고서: MergeCommand
+
+**이슈**: #38  
+**브랜치**: `local/task20`  
+**마일스톤**: v0.3 — 편집 커맨드  
+**완료일**: 2026-05-04
+
+---
+
+## 완료 내용
+
+`rpdf-edit` 크레이트에 `MergeCommand`를 추가했다.  
+하나 이상의 소스 Document 페이지를 대상 Document 뒤에 순서대로 append하고,  
+Undo 시 truncate로 원래 상태를 복원한다.
+
+### 변경 파일
+
+| 파일 | 변경 내용 |
+|------|---------|
+| `crates/rpdf-edit/src/commands/merge.rs` | 신규 생성 — MergeCommand + 13개 단위 테스트 |
+| `crates/rpdf-edit/src/commands/mod.rs` | merge 모듈 등록, MergeCommand re-export, reindex_pages 헬퍼 추가 |
+| `crates/rpdf-edit/src/commands/delete.rs` | 인라인 reindex 루프 2개 → reindex_pages() 호출로 교체 |
+
+---
+
+## 구현 결정 사항
+
+### MergeCommand 구조체
+
+```rust
+pub struct MergeCommand {
+    sources: Vec<Document>,
+    snapshot: Mutex<Option<usize>>,
+}
+```
+
+- `snapshot: Mutex<Option<usize>>` — execute 전 `doc.pages.len()`만 저장. Page clone 없음.
+- `Mutex<T>`: `Command: Send + Sync` 경계 충족.
+
+### reindex_pages DRY 추출
+
+`pub(crate) fn reindex_pages(pages: &mut [Page])`를 `mod.rs`에 추가.  
+이전 delete.rs의 인라인 루프 2개 + merge.rs 2개 → 4회 등장 → CLAUDE.md "3회 등장 → 추출" 기준 충족.
+
+### undo 방식
+
+`doc.pages.truncate(original_len)` — append 기반이므로 truncate만으로 완전 복원 가능.  
+DeletePagesCommand처럼 페이지별 스냅샷 불필요.
+
+---
+
+## 계획 대비 달라진 점
+
+없음. 계획서를 그대로 구현했다.
+
+단, evaluator 지적으로 `merge_multiple_sources` 테스트에 소스 간 순서 검증(rotation 값 비교)을 추가함.  
+계획서에는 "소스 간 순서 보존"이 완료 기준에 있었으나 테스트에 명시적 assertion이 빠져있었음.
+
+---
+
+## 품질 게이트
+
+| 항목 | 결과 |
+|------|------|
+| `cargo test -p rpdf-edit` | 48 passed, 0 failed |
+| doctest | 3 passed (rotate, merge, delete) |
+| `cargo clippy -p rpdf-edit -- -D warnings` | 경고 0개 |
+| `cargo fmt --check` | 통과 |
+
+---
+
+## 배운 점
+
+- `truncate` 기반 undo는 append-only 패턴에서 매우 단순하고 효율적이다.  
+  DeletePagesCommand의 페이지별 스냅샷과 대조되는 설계.
+- "소스 페이지 순서 보존" 같은 정책은 구현이 자연스럽게 보장해도, 테스트가 명시적으로 검증해야 완료 기준을 충족한다.
+
+---
+
+## 회고 분류 표
+
+| # | 항목 요약 | 카테고리 | 판단 근거 |
+|---|---------|---------|---------|
+| 1 | 소스 간 순서 보존 → 테스트에 명시적 assertion 필요 | **C: 스킵** | CLAUDE.md §체크포인트 셀프 리뷰에 "조건 분기 실제 실행 확인" 이미 있음. 새 규칙 불필요 |
+| 2 | append-only undo는 truncate로 충분 (snapshot 최소화 패턴) | **C: 스킵** | 구현 패턴은 코드로 남음. 별도 규칙 가치 없음 |


### PR DESCRIPTION
## Summary

- `MergeCommand` 신규 구현: 하나 이상의 소스 Document 페이지를 대상 Document 뒤에 순서대로 append
- `snapshot: Mutex<Option<usize>>` — original_len만 저장, Page clone 없음
- `reindex_pages` 헬퍼를 `mod.rs`에 `pub(crate)` 추출 — delete.rs·merge.rs 공유 (DRY)
- 13개 단위 테스트 + 1개 doctest

## Test plan

- [x] `cargo test -p rpdf-edit` — 48 passed, 0 failed
- [x] doctest 3 passed (rotate, merge, delete)
- [x] `cargo clippy -p rpdf-edit -- -D warnings` — 경고 0개
- [x] `cargo fmt --check` — 통과
- [x] execute/undo/redo 라운드트립 (`execute_undo_redo_via_stack`)
- [x] 소스 간 순서 보존 (`merge_multiple_sources` — rotation 값으로 검증)
- [x] 이중 execute 방어, undo-before-execute 방어

closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)