### PR TITLE
Task #22: ExtractPagesCommand 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,15 @@ private/`pub(crate)` 함수 테스트 → 인라인 `#[cfg(test)] mod internal_t
 > **이유**: `tests/` 폴더는 크레이트 외부에서 컴파일되므로 `pub(crate)` 함수에 접근할 수 없다.
 > 공개 API만으로 동등한 검증이 가능하면 별도 파일을 우선한다.
 
+### 테스트 헬퍼 공유 (인라인 `#[cfg(test)]` 모듈 간)
+
+같은 크레이트 내 여러 모듈이 동일한 테스트 헬퍼를 공유해야 한다면,
+`mod.rs`에 `#[cfg(test)] pub(crate) mod test_utils {}` 를 추가하고
+각 하위 모듈에서 `use super::test_utils::헬퍼명;` 으로 임포트한다.
+세 번 이상 중복이 발생하면 즉시 통합한다.
+
+> **사례**: `rpdf-edit`의 `make_doc` 헬퍼가 rotate.rs·delete.rs·merge.rs·split.rs에 4번 중복된 채 방치됐다가 Task #22에서 통합됨.
+
 ### 체크포인트 시점 셀프 리뷰
 
 각 체크포인트(빌드·테스트 통과 직후) 다음으로 넘어가기 전, 명세 위반 시나리오를 능동적으로 탐색한다.

--- a/crates/rpdf-edit/src/commands/delete.rs
+++ b/crates/rpdf-edit/src/commands/delete.rs
@@ -109,27 +109,9 @@ impl Command for DeletePagesCommand {
 
 #[cfg(test)]
 mod tests {
-    use rpdf_core::types::document::{Document, Page};
-
     use super::*;
     use crate::commands::CommandStack;
-
-    fn make_doc(pages: usize, rotations: &[i32]) -> Document {
-        let page_vec = (0..pages)
-            .map(|i| Page {
-                index: i,
-                content: vec![],
-                resources: None,
-                media_box: None,
-                crop_box: None,
-                rotation: rotations.get(i).copied().unwrap_or(0),
-            })
-            .collect();
-        Document {
-            pages: page_vec,
-            metadata: None,
-        }
-    }
+    use crate::commands::test_utils::make_doc;
 
     #[test]
     fn delete_single_page() {

--- a/crates/rpdf-edit/src/commands/extract.rs
+++ b/crates/rpdf-edit/src/commands/extract.rs
@@ -1,0 +1,231 @@
+use rpdf_core::types::document::Document;
+
+use crate::commands::{CommandError, Query, reindex_pages};
+
+/// 단일 페이지 범위를 추출해 새 Document를 반환하는 쿼리.
+///
+/// 1-based 시작/끝 페이지 번호로 범위를 지정한다.
+/// 원본 Document는 변경하지 않는다.
+///
+/// # Examples
+///
+/// ```rust
+/// use rpdf_edit::commands::{ExtractPagesCommand, Query};
+/// use rpdf_core::types::document::{Document, Page};
+///
+/// let pages = (0..5)
+///     .map(|i| Page {
+///         index: i,
+///         content: vec![],
+///         resources: None,
+///         media_box: None,
+///         crop_box: None,
+///         rotation: 0,
+///     })
+///     .collect();
+/// let doc = Document { pages, metadata: None };
+///
+/// // 1-based 페이지 번호: 2~4번 페이지 추출 → 3페이지 Document
+/// let cmd = ExtractPagesCommand::new(2, 4).unwrap();
+/// let result = cmd.execute(&doc).unwrap();
+/// assert_eq!(result.pages.len(), 3);
+/// ```
+#[derive(Debug)]
+pub struct ExtractPagesCommand {
+    start: usize, // 0-based, inclusive
+    end: usize,   // 0-based, inclusive
+}
+
+impl ExtractPagesCommand {
+    /// 1-based 시작/끝 페이지 번호로 `ExtractPagesCommand`를 생성한다.
+    ///
+    /// # Arguments
+    /// * `start_page` - 추출 시작 페이지 (1-based, inclusive)
+    /// * `end_page` - 추출 끝 페이지 (1-based, inclusive)
+    ///
+    /// # Errors
+    ///
+    /// - `start_page == 0` 또는 `end_page == 0`: `ExecutionFailed("page numbers are 1-based, got 0")`
+    /// - `start_page > end_page`: `ExecutionFailed("invalid range N-M: start > end")`
+    pub fn new(start_page: usize, end_page: usize) -> Result<Self, CommandError> {
+        if start_page == 0 || end_page == 0 {
+            return Err(CommandError::ExecutionFailed(
+                "page numbers are 1-based, got 0".to_string(),
+            ));
+        }
+        if start_page > end_page {
+            return Err(CommandError::ExecutionFailed(format!(
+                "invalid range {start_page}-{end_page}: start > end"
+            )));
+        }
+        Ok(Self {
+            start: start_page - 1,
+            end: end_page - 1,
+        })
+    }
+}
+
+impl Query for ExtractPagesCommand {
+    type Output = Document;
+
+    fn execute(&self, doc: &Document) -> Result<Document, CommandError> {
+        if doc.pages.is_empty() {
+            return Err(CommandError::ExecutionFailed(
+                "document has no pages".to_string(),
+            ));
+        }
+        if self.end >= doc.pages.len() {
+            return Err(CommandError::ExecutionFailed(format!(
+                "page index out of bounds: {}",
+                self.end
+            )));
+        }
+        let mut pages = doc.pages[self.start..=self.end].to_vec();
+        reindex_pages(&mut pages);
+        Ok(Document {
+            pages,
+            metadata: doc.metadata.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rpdf_core::types::document::DocumentMetadata;
+
+    use super::super::test_utils::make_doc;
+    use super::*;
+
+    #[test]
+    fn extract_basic_range() {
+        let doc = make_doc(5, &[]);
+        let cmd = ExtractPagesCommand::new(2, 4).unwrap();
+        let result = cmd.execute(&doc).unwrap();
+        assert_eq!(result.pages.len(), 3);
+    }
+
+    #[test]
+    fn extract_single_page() {
+        let doc = make_doc(5, &[]);
+        let cmd = ExtractPagesCommand::new(3, 3).unwrap();
+        let result = cmd.execute(&doc).unwrap();
+        assert_eq!(result.pages.len(), 1);
+    }
+
+    #[test]
+    fn extract_entire_document() {
+        let doc = make_doc(5, &[]);
+        let cmd = ExtractPagesCommand::new(1, 5).unwrap();
+        let result = cmd.execute(&doc).unwrap();
+        assert_eq!(result.pages.len(), 5);
+    }
+
+    #[test]
+    fn extract_preserves_page_content() {
+        let doc = make_doc(3, &[90, 180, 270]);
+        let cmd = ExtractPagesCommand::new(1, 3).unwrap();
+        let result = cmd.execute(&doc).unwrap();
+        assert_eq!(result.pages[0].rotation, 90);
+        assert_eq!(result.pages[1].rotation, 180);
+        assert_eq!(result.pages[2].rotation, 270);
+    }
+
+    #[test]
+    fn extract_page_indices_reindexed() {
+        let doc = make_doc(5, &[]);
+        let cmd = ExtractPagesCommand::new(2, 4).unwrap();
+        let result = cmd.execute(&doc).unwrap();
+        assert_eq!(result.pages[0].index, 0);
+        assert_eq!(result.pages[1].index, 1);
+        assert_eq!(result.pages[2].index, 2);
+    }
+
+    #[test]
+    fn extract_metadata_copied() {
+        let mut doc = make_doc(3, &[]);
+        doc.metadata = Some(DocumentMetadata {
+            title: Some(b"Test".to_vec()),
+            ..Default::default()
+        });
+        let cmd = ExtractPagesCommand::new(1, 2).unwrap();
+        let result = cmd.execute(&doc).unwrap();
+        assert!(result.metadata.is_some());
+        let meta = result.metadata.as_ref().unwrap();
+        assert_eq!(meta.title, Some(b"Test".to_vec()));
+    }
+
+    #[test]
+    fn extract_out_of_bounds_end() {
+        let doc = make_doc(5, &[]);
+        let cmd = ExtractPagesCommand::new(1, 10).unwrap();
+        let err = cmd.execute(&doc).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("page index out of bounds"));
+        }
+    }
+
+    #[test]
+    fn extract_start_out_of_bounds() {
+        let doc = make_doc(5, &[]);
+        let cmd = ExtractPagesCommand::new(8, 10).unwrap();
+        let err = cmd.execute(&doc).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn extract_zero_start_page() {
+        let err = ExtractPagesCommand::new(0, 3).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("1-based"));
+        }
+    }
+
+    #[test]
+    fn extract_zero_end_page() {
+        let err = ExtractPagesCommand::new(1, 0).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("1-based"));
+        }
+    }
+
+    #[test]
+    fn extract_start_greater_than_end() {
+        let err = ExtractPagesCommand::new(4, 2).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("start > end"));
+        }
+    }
+
+    #[test]
+    fn extract_on_empty_document() {
+        let doc = make_doc(0, &[]);
+        let cmd = ExtractPagesCommand::new(1, 1).unwrap();
+        let err = cmd.execute(&doc).unwrap_err();
+        assert!(matches!(err, CommandError::ExecutionFailed(_)));
+        if let CommandError::ExecutionFailed(msg) = err {
+            assert!(msg.contains("document has no pages"));
+        }
+    }
+
+    #[test]
+    fn extract_original_doc_unchanged() {
+        let doc = make_doc(5, &[]);
+        let original_len = doc.pages.len();
+        let cmd = ExtractPagesCommand::new(1, 3).unwrap();
+        cmd.execute(&doc).unwrap();
+        assert_eq!(doc.pages.len(), original_len);
+    }
+
+    #[test]
+    fn extract_last_page_boundary() {
+        let doc = make_doc(5, &[]);
+        let cmd = ExtractPagesCommand::new(5, 5).unwrap();
+        let result = cmd.execute(&doc).unwrap();
+        assert_eq!(result.pages.len(), 1);
+        assert_eq!(result.pages[0].index, 0);
+    }
+}

--- a/crates/rpdf-edit/src/commands/merge.rs
+++ b/crates/rpdf-edit/src/commands/merge.rs
@@ -97,27 +97,9 @@ impl Command for MergeCommand {
 
 #[cfg(test)]
 mod tests {
-    use rpdf_core::types::document::{Document, Page};
-
     use super::*;
     use crate::commands::CommandStack;
-
-    fn make_doc(pages: usize, rotations: &[i32]) -> Document {
-        let page_vec = (0..pages)
-            .map(|i| Page {
-                index: i,
-                content: vec![],
-                resources: None,
-                media_box: None,
-                crop_box: None,
-                rotation: rotations.get(i).copied().unwrap_or(0),
-            })
-            .collect();
-        Document {
-            pages: page_vec,
-            metadata: None,
-        }
-    }
+    use crate::commands::test_utils::make_doc;
 
     #[test]
     fn merge_single_source() {

--- a/crates/rpdf-edit/src/commands/mod.rs
+++ b/crates/rpdf-edit/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod delete;
 mod error;
+mod extract;
 mod merge;
 mod rotate;
 mod split;
@@ -8,6 +9,7 @@ mod traits;
 
 pub use delete::DeletePagesCommand;
 pub use error::CommandError;
+pub use extract::ExtractPagesCommand;
 pub use merge::MergeCommand;
 pub use rotate::RotatePageCommand;
 pub use split::SplitCommand;
@@ -20,5 +22,27 @@ use rpdf_core::types::document::Page;
 pub(crate) fn reindex_pages(pages: &mut [Page]) {
     for (i, page) in pages.iter_mut().enumerate() {
         page.index = i;
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use rpdf_core::types::document::{Document, Page};
+
+    pub fn make_doc(pages: usize, rotations: &[i32]) -> Document {
+        let page_vec = (0..pages)
+            .map(|i| Page {
+                index: i,
+                content: vec![],
+                resources: None,
+                media_box: None,
+                crop_box: None,
+                rotation: rotations.get(i).copied().unwrap_or(0),
+            })
+            .collect();
+        Document {
+            pages: page_vec,
+            metadata: None,
+        }
     }
 }

--- a/crates/rpdf-edit/src/commands/rotate.rs
+++ b/crates/rpdf-edit/src/commands/rotate.rs
@@ -81,27 +81,9 @@ impl Command for RotatePageCommand {
 
 #[cfg(test)]
 mod tests {
-    use rpdf_core::types::document::{Document, Page};
-
     use super::*;
     use crate::commands::CommandStack;
-
-    fn make_doc(pages: usize, rotations: &[i32]) -> Document {
-        let page_vec = (0..pages)
-            .map(|i| Page {
-                index: i,
-                content: vec![],
-                resources: None,
-                media_box: None,
-                crop_box: None,
-                rotation: rotations.get(i).copied().unwrap_or(0),
-            })
-            .collect();
-        Document {
-            pages: page_vec,
-            metadata: None,
-        }
-    }
+    use crate::commands::test_utils::make_doc;
 
     #[test]
     fn rotate_90_forward() {

--- a/crates/rpdf-edit/src/commands/split.rs
+++ b/crates/rpdf-edit/src/commands/split.rs
@@ -164,26 +164,10 @@ impl Query for SplitCommand {
 
 #[cfg(test)]
 mod tests {
-    use rpdf_core::types::document::{Document, DocumentMetadata, Page};
+    use rpdf_core::types::document::DocumentMetadata;
 
     use super::*;
-
-    fn make_doc(pages: usize, rotations: &[i32]) -> Document {
-        let page_vec = (0..pages)
-            .map(|i| Page {
-                index: i,
-                content: vec![],
-                resources: None,
-                media_box: None,
-                crop_box: None,
-                rotation: rotations.get(i).copied().unwrap_or(0),
-            })
-            .collect();
-        Document {
-            pages: page_vec,
-            metadata: None,
-        }
-    }
+    use crate::commands::test_utils::make_doc;
 
     #[test]
     fn split_single_range() {

--- a/mydocs/plans/task22-extract-pages-command.md
+++ b/mydocs/plans/task22-extract-pages-command.md
@@ -1,0 +1,261 @@
+# Task #22: ExtractPagesCommand 구현
+
+**이슈**: #42  
+**브랜치**: `local/task22`  
+**마일스톤**: v0.3 — 편집 커맨드  
+**선행 조건**: Task #21 완료 (`SplitCommand`)
+
+---
+
+## 목표
+
+`rpdf-edit` 크레이트에 `ExtractPagesCommand`를 추가한다.  
+`SplitCommand`의 간소화 버전으로, 연속된 단일 페이지 범위를 추출해 새 `Document` 하나를 반환한다.  
+원본 Document는 **변경하지 않는다**.
+
+---
+
+## 설계 결정
+
+### `Query` 트레이트 구현 (Command 아님)
+
+`ExtractPagesCommand`는 원본 Document를 변경하지 않으므로 `Query` 트레이트를 구현한다.
+
+```rust
+pub trait Query {
+    type Output;
+    fn execute(&self, doc: &Document) -> Result<Self::Output, CommandError>;
+}
+```
+
+`ExtractPagesCommand`는 `type Output = Document` — 단일 Document 반환.  
+`CommandStack`에 push하지 않는다.
+
+### SplitCommand와의 차이
+
+| 항목 | SplitCommand | ExtractPagesCommand |
+|------|-------------|---------------------|
+| 입력 형식 | 문자열 명세 (`"1-3,5,7-10"`) | 1-based 시작/끝 페이지 번호 |
+| 범위 수 | 다수 범위 허용 | 단일 범위만 |
+| 출력 타입 | `Vec<Document>` | `Document` |
+
+`ExtractPagesCommand`는 명시적 정수 인터페이스를 사용한다 — 더 단순하고, 문자열 파싱 오류가 없다.  
+문자열 명세가 필요하면 `SplitCommand`를 사용한다.
+
+### 생성자 인터페이스
+
+```rust
+pub fn new(start_page: usize, end_page: usize) -> Result<Self, CommandError>
+```
+
+- 1-based 페이지 번호 입력 (사용자 친화적, SplitCommand 정책과 일관)
+- 내부에서 0-based로 변환하여 저장
+- `start_page == 0` 또는 `end_page == 0` → `ExecutionFailed("page numbers are 1-based, got 0")`
+- `start_page > end_page` → `ExecutionFailed("invalid range N-M: start > end")`
+- 성공 시 `Ok(Self { start: start_page - 1, end: end_page - 1 })`
+
+### 구조체
+
+```rust
+pub struct ExtractPagesCommand {
+    start: usize, // 0-based, inclusive
+    end: usize,   // 0-based, inclusive
+}
+```
+
+### execute 로직
+
+```rust
+fn execute(&self, doc: &Document) -> Result<Document, CommandError> {
+    // 1. doc.pages.is_empty() → ExecutionFailed("document has no pages")
+    // 2. self.end >= doc.pages.len() → ExecutionFailed("page index out of bounds: {end}")
+    // 3. doc.pages[self.start..=self.end] clone → pages
+    // 4. reindex_pages(&mut pages)
+    // 5. Ok(Document { pages, metadata: doc.metadata.clone() })
+}
+```
+
+**메타데이터 정책**: 원본 Document의 `metadata`를 출력 Document에 그대로 복사한다.  
+(SplitCommand와 동일한 정책 — 일관성 유지)
+
+### 에러 처리
+
+| 조건 | 에러 | 발생 위치 |
+|------|------|---------|
+| `start_page == 0` | `ExecutionFailed("page numbers are 1-based, got 0")` | `new()` |
+| `end_page == 0` | `ExecutionFailed("page numbers are 1-based, got 0")` | `new()` |
+| `start_page > end_page` | `ExecutionFailed("invalid range N-M: start > end")` | `new()` |
+| 0-page Document | `ExecutionFailed("document has no pages")` | `execute()` |
+| `end >= doc.pages.len()` | `ExecutionFailed("page index out of bounds: {end}")` | `execute()` |
+
+> **교차 검증**: 에러 표의 5개 항목이 execute() 로직 설명의 단계 1~2에 모두 대응된다.  
+> - 에러 항목 1~3 → `new()` 단계  
+> - 에러 항목 4 → 로직 단계 1  
+> - 에러 항목 5 → 로직 단계 2
+
+---
+
+## 위치
+
+`crates/rpdf-edit/src/commands/extract.rs` 신규 파일.  
+`mod.rs`에서 `mod extract; pub use extract::ExtractPagesCommand;` 추가.
+
+### mod.rs 변경
+
+```rust
+mod delete;
+mod error;
+mod extract;   // 신규
+mod merge;
+mod rotate;
+mod split;
+mod stack;
+mod traits;
+
+pub use delete::DeletePagesCommand;
+pub use error::CommandError;
+pub use extract::ExtractPagesCommand;  // 신규
+pub use merge::MergeCommand;
+pub use rotate::RotatePageCommand;
+pub use split::SplitCommand;
+pub use stack::CommandStack;
+pub use traits::{Command, Query};
+```
+
+---
+
+## 테스트 전략
+
+### make_doc 헬퍼 통합 (DRY 리팩터링)
+
+`make_doc(pages: usize, rotations: &[i32]) -> Document` 헬퍼가 rotate.rs, delete.rs, merge.rs, split.rs에 이미 4번 중복되어 있다. CLAUDE.md DRY 룰("세 번 등장하면 추출 검토") 기준 초과. 이 PR에서 `mod.rs`에 공유 헬퍼를 이동하고 각 파일이 이를 사용하도록 수정한다.
+
+```rust
+// commands/mod.rs 에 추가
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use rpdf_core::types::document::{Document, Page};
+
+    pub fn make_doc(pages: usize, rotations: &[i32]) -> Document {
+        let page_vec = (0..pages)
+            .map(|i| Page {
+                index: i,
+                content: vec![],
+                resources: None,
+                media_box: None,
+                crop_box: None,
+                rotation: rotations.get(i).copied().unwrap_or(0),
+            })
+            .collect();
+        Document { pages: page_vec, metadata: None }
+    }
+}
+```
+
+각 테스트 파일은 `use super::super::test_utils::make_doc;` (또는 동등한 경로)로 임포트.
+
+### 테스트 목록
+
+위치: `extract.rs` 하단 `#[cfg(test)] mod tests {}`
+
+| # | 테스트명 | 검증 내용 |
+|---|---------|---------|
+| 1 | `extract_basic_range` | `new(2, 4)`, 5-page doc → 3페이지 doc |
+| 2 | `extract_single_page` | `new(3, 3)`, 5-page doc → 1페이지 doc |
+| 3 | `extract_entire_document` | `new(1, 5)`, 5-page doc → 5페이지 doc |
+| 4 | `extract_preserves_page_content` | rotation·media_box 원본 값 보존 |
+| 5 | `extract_page_indices_reindexed` | 출력 doc의 pages[i].index = i |
+| 6 | `extract_metadata_copied` | 원본 metadata가 출력 doc에 복사됨 |
+| 7 | `extract_out_of_bounds_end` | `new(1, 10)`, 5-page doc → `ExecutionFailed` |
+| 8 | `extract_start_out_of_bounds` | `new(8, 10)`, 5-page doc → `ExecutionFailed` |
+| 9 | `extract_zero_start_page` | `new(0, 3)` → `new()` 에러 (`"1-based"`) |
+| 10 | `extract_zero_end_page` | `new(1, 0)` → `new()` 에러 (`"1-based"`) |
+| 11 | `extract_start_greater_than_end` | `new(4, 2)` → `new()` 에러 (`"start > end"`) |
+| 12 | `extract_on_empty_document` | 0-page doc + `new(1, 1)` → `execute()` 에러 |
+| 13 | `extract_original_doc_unchanged` | execute 후 원본 doc.pages.len() 변화 없음 |
+| 14 | `extract_last_page_boundary` | `new(5, 5)`, 5-page doc → 1페이지 doc (0-based end == len-1 경계) |
+
+---
+
+## 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| `start_page == end_page` | 허용. 1-page Document 반환 |
+| 0-page doc | `execute()` → `ExecutionFailed("document has no pages")` |
+| `end >= doc.pages.len()` | `execute()` → `ExecutionFailed` |
+| `start_page == 1, end_page == doc.pages.len()` | 전체 추출. 원본 복사본 반환 |
+
+---
+
+## NOT in scope
+
+| 항목 | 이유 |
+|------|------|
+| 문자열 명세 파싱 (`"3-7"`) | SplitCommand 담당. YAGNI |
+| 비연속 범위 지원 | SplitCommand 담당. YAGNI |
+| `CommandStack` 등록 | Query는 undo 불필요 |
+| 출력 Document 메타데이터 개별 지정 | YAGNI. 원본 복사 정책으로 충분 |
+| Outlines/Bookmarks/Annotations 내부 참조 업데이트 | 추출 후 제거된 페이지를 가리키는 Bookmark 등은 dangling 상태가 됨. v0.4 이후 full PDF rewrite 모드에서 처리. SplitCommand도 동일한 한계. |
+
+---
+
+## 의존성
+
+- `rpdf_core::types::document::{Document, Page}` — `Clone` 확인됨
+- `rpdf_edit::commands::{Query, CommandError}` — 기존
+- `super::reindex_pages` — 기존 `pub(crate)` 헬퍼
+- 신규 외부 의존성 없음
+
+---
+
+## 체크포인트
+
+| 체크포인트 | 내용 | 완료 조건 |
+|-----------|------|-----------|
+| CP-1 | `extract.rs` 생성 + `mod.rs` 등록 | `cargo build -p rpdf-edit` 통과 |
+| CP-2 | `new()` + `execute()` 구현 | `cargo build -p rpdf-edit` 통과 |
+| CP-3 | 14개 단위 테스트 | `cargo test -p rpdf-edit` 통과 |
+| CP-4 | 전체 품질 게이트 | `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` |
+
+---
+
+## 완료 기준
+
+1. `ExtractPagesCommand`가 `rpdf_edit::commands::ExtractPagesCommand`로 공개 API 노출됨
+2. `Query` 트레이트 구현, `type Output = Document`
+3. 1-based 시작/끝 페이지 번호를 `new()` 시점에 검증
+4. 출력 Document의 `Page.index` 재정렬 (0-based)
+5. 원본 Document 변경 없음 (`extract_original_doc_unchanged` 테스트로 검증)
+6. 14개 단위 테스트 통과 (테스트 #14: `extract_last_page_boundary` 포함)
+7. `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` 통과
+8. 공개 API `///` 문서 주석 + `# Examples` 섹션
+9. `new()` 문서에 1-based 페이지 번호 명시
+
+---
+
+## Implementation Tasks
+
+- [ ] **T1 (P2, human: ~30min / CC: ~5min)** — rpdf-edit/commands — `make_doc` 테스트 헬퍼를 `mod.rs` `test_utils`로 통합
+  - Surfaced by: Code Quality — rotate.rs, delete.rs, merge.rs, split.rs, extract.rs 5개 파일 중복 (DRY 임계값 초과)
+  - Files: `commands/mod.rs`, `commands/rotate.rs`, `commands/delete.rs`, `commands/merge.rs`, `commands/split.rs`, `commands/extract.rs`
+  - Verify: `cargo test -p rpdf-edit` 통과
+- [ ] **T2 (P2, human: ~5min / CC: ~1min)** — rpdf-edit/commands/extract.rs — `extract_last_page_boundary` 테스트 추가
+  - Surfaced by: Test Review — `new(n, n)` on n-page doc (0-based end == len-1) 경계값 미검증
+  - Files: `crates/rpdf-edit/src/commands/extract.rs`
+  - Verify: `cargo test -p rpdf-edit extract_last_page_boundary` 통과
+- [ ] **T3 (P3, human: ~5min / CC: ~1min)** — 계획서 NOT in scope 업데이트 (이미 완료됨)
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Outside Voice | Gemini CLI (폴백: Claude subagent) | Independent 2nd opinion | 1 | CLEAR | 6건 중 2 false positive, 1 scope-out, 3건 반영 (make_doc 통합, last-page boundary 테스트, NOT in scope 명시) |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 3건 발견 → 계획서 반영 완료 |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | N/A (no UI) |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+**VERDICT:** ENG CLEARED — 구현 시작 가능.


### PR DESCRIPTION
## Summary

- `ExtractPagesCommand` 신규 구현 (`Query` 트레이트, `type Output = Document`)
- 1-based 시작/끝 페이지 번호 입력 → 단일 페이지 범위 추출 → 새 `Document` 반환
- 원본 Document 불변 보장
- `make_doc` 테스트 헬퍼 DRY 리팩터링 — 4개 파일 중복 → `mod.rs` `test_utils` 공유 모듈로 통합

## Changes

| 파일 | 변경 |
|------|------|
| `crates/rpdf-edit/src/commands/extract.rs` | 신규 — `ExtractPagesCommand` 구현 + 14개 단위 테스트 |
| `crates/rpdf-edit/src/commands/mod.rs` | `extract` 모듈 등록, `test_utils` 공유 모듈 추가 |
| `crates/rpdf-edit/src/commands/rotate.rs` | 로컬 `make_doc` 제거 → `test_utils` 임포트 |
| `crates/rpdf-edit/src/commands/delete.rs` | 동일 |
| `crates/rpdf-edit/src/commands/merge.rs` | 동일 |
| `crates/rpdf-edit/src/commands/split.rs` | 동일 |
| `CLAUDE.md` | 테스트 헬퍼 공유 패턴 룰 추가 |

## Test plan

- [x] `cargo test --workspace --exclude rpdf-render` — 78 unit + 5 doctest 전체 통과
- [x] `cargo clippy --workspace --exclude rpdf-render -- -D warnings` — 경고 0
- [x] `cargo fmt --all --check` — 통과
- [x] `extract_last_page_boundary`: `new(5, 5)` on 5-page doc (0-based end == len-1 경계값)
- [x] `extract_original_doc_unchanged`: execute 후 원본 불변 확인

closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)