### PR TITLE
Task #23: rpdf-serializer 크레이트 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,15 @@ PDF 스펙(ISO 32000) 용어를 코드에 그대로 반영한다.
 > 열린 `<g transform>` 태그를 닫지 않아 `cm → q` 패턴 PDF에서 SVG 구조 파손.
 > → `SaveState` 진입 전에 `for _ in 0..loose_cm_depth { out.push_str("</g>\n"); }` 실행.
 
+### PDF 속성 직렬화 — 항상 명시적 쓰기
+
+PDF 속성(rotation 등)을 직렬화할 때 "값이 기본값이면 생략" 조건 분기를 두지 않는다.
+항상 현재 값으로 덮어쓴다.
+
+> **사례**: `serialize_document`에서 `rotation ≠ 0`일 때만 `/Rotate`를 설정하면,
+> 원본이 `/Rotate 90`인 페이지를 0도로 복원할 때 조건 미충족 → 원본 값 90이 그대로 남는 버그.
+> → 조건 분기 없이 항상 `page.rotation` 값으로 `/Rotate`를 설정해 해결.
+
 ### 테스트 파일 배치
 
 공개 API 테스트 → `tests/parser/<module>_tests.rs` (별도 파일). 새 모듈 추가 시 `mod.rs`에 등록.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +136,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +169,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -166,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +226,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +247,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -278,6 +343,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,10 +370,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "either"
@@ -303,6 +449,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -397,6 +552,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +582,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -500,6 +666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +708,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -580,10 +797,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lopdf"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fdcbab5b237a03984f83b1394dc534e0b1960675c7f3ec4d04dccc9032b56d"
+dependencies = [
+ "aes",
+ "bitflags",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.4.2",
+ "indexmap",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5",
+ "nom",
+ "nom_locate",
+ "rand 0.10.1",
+ "rangemap",
+ "rayon",
+ "sha2",
+ "stringprep",
+ "thiserror",
+ "time",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -612,10 +871,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -690,6 +975,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +1063,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -806,7 +1112,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -816,7 +1133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -829,12 +1146,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -920,6 +1269,17 @@ dependencies = [
  "image",
  "pdfium-render",
  "rpdf-core",
+ "thiserror",
+]
+
+[[package]]
+name = "rpdf-serializer"
+version = "0.1.0"
+dependencies = [
+ "lopdf",
+ "rpdf-core",
+ "rpdf-edit",
+ "rpdf-parser",
  "thiserror",
 ]
 
@@ -1012,6 +1372,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1405,17 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -1092,6 +1474,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,16 +1551,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -1163,6 +1624,12 @@ checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
 dependencies = [
  "piston-float",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -1289,6 +1756,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = ["crates/rpdf-cli",
     "crates/rpdf-core", "crates/rpdf-edit", "crates/rpdf-parser", "crates/rpdf-render", "crates/rpdf-svg",
+    "crates/rpdf-serializer",
 ]
 
 [workspace.package]
@@ -16,7 +17,9 @@ rpdf-core = { path = "crates/rpdf-core" }
 rpdf-edit = { path = "crates/rpdf-edit" }
 rpdf-parser = { path = "crates/rpdf-parser" }
 rpdf-render = { path = "crates/rpdf-render" }
+rpdf-serializer = { path = "crates/rpdf-serializer" }
 rpdf-svg = { path = "crates/rpdf-svg" }
+lopdf = "0.40.0"
 thiserror = "2"
 anyhow = "1"
 tracing = "0.1"

--- a/crates/rpdf-serializer/Cargo.toml
+++ b/crates/rpdf-serializer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rpdf-serializer"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+rpdf-core.workspace = true
+rpdf-parser.workspace = true
+lopdf.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+rpdf-edit.workspace = true

--- a/crates/rpdf-serializer/src/error.rs
+++ b/crates/rpdf-serializer/src/error.rs
@@ -1,0 +1,23 @@
+/// `serialize_document` 호출 시 발생 가능한 에러.
+#[derive(Debug, thiserror::Error)]
+pub enum SerializeError {
+    /// pages가 비어있음.
+    #[error("document has no pages")]
+    EmptyDocument,
+
+    /// sources와 pages 개수 불일치.
+    #[error("sources length {sources} != pages length {pages}")]
+    SourceLengthMismatch { sources: usize, pages: usize },
+
+    /// lopdf가 source_bytes 로드 실패 (이중 파서 비호환).
+    #[error("failed to load source PDF (lopdf incompatible): {0}")]
+    LoadSource(lopdf::Error),
+
+    /// source.page_index가 원본 페이지 수 초과.
+    #[error("source_page_index {idx} out of bounds (source has {count} pages)")]
+    PageOutOfBounds { idx: usize, count: usize },
+
+    /// lopdf save_to 실패.
+    #[error("lopdf save failed: {0}")]
+    Save(#[from] std::io::Error),
+}

--- a/crates/rpdf-serializer/src/lib.rs
+++ b/crates/rpdf-serializer/src/lib.rs
@@ -1,0 +1,12 @@
+//! rpdf-serializer: Document IR → PDF 바이트 직렬화 크레이트.
+//!
+//! lopdf를 백엔드로 사용해 편집된 Document를 유효한 PDF로 저장한다.
+//! `rpdf-core`, `rpdf-parser`, `rpdf-edit`의 변경 없이 직렬화 관심사만 담당한다.
+
+mod error;
+mod serialize;
+mod types;
+
+pub use error::SerializeError;
+pub use serialize::{load_document_tracked, serialize_document};
+pub use types::PageSource;

--- a/crates/rpdf-serializer/src/serialize.rs
+++ b/crates/rpdf-serializer/src/serialize.rs
@@ -1,0 +1,360 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+
+use rpdf_core::types::document::Document;
+use rpdf_parser::{ParseError, load_document};
+
+use crate::error::SerializeError;
+use crate::types::PageSource;
+
+/// PDF 바이트에서 `Document`와 `PageSource` 목록을 함께 반환한다.
+///
+/// `Document.pages[i]`에 대응하는 원본 출처가 `sources[i]`에 담겨있다.
+/// 커맨드 실행 후에는 호출자가 `sources`를 `pages`와 동기화해야 한다.
+///
+/// # Errors
+///
+/// - [`ParseError`] — rpdf-parser 파싱 실패 시
+pub fn load_document_tracked(data: &[u8]) -> Result<(Document, Vec<PageSource>), ParseError> {
+    let doc = load_document(data)?;
+    // 한 번만 clone해 모든 PageSource가 공유하도록 Arc로 감싼다.
+    let bytes_arc = Arc::new(data.to_vec());
+    let sources = doc
+        .pages
+        .iter()
+        .map(|p| PageSource {
+            bytes: Arc::clone(&bytes_arc),
+            page_index: p.index,
+        })
+        .collect();
+    Ok((doc, sources))
+}
+
+/// `Document` IR을 PDF 바이트로 직렬화한다.
+///
+/// `sources[i]`는 `doc.pages[i]`의 원본 출처여야 한다.
+/// `sources.len() != doc.pages.len()`이면 에러를 반환한다.
+///
+/// # 소스 동일성 판별
+///
+/// `Arc::ptr_eq`로 포인터를 비교해 단일 소스(같은 파일)와
+/// 다중 소스(MergeCommand 결과)를 구분한다.
+///
+/// # Errors
+///
+/// - [`SerializeError::EmptyDocument`] — pages가 비어있음
+/// - [`SerializeError::SourceLengthMismatch`] — sources와 pages 개수 불일치
+/// - [`SerializeError::LoadSource`] — lopdf가 source_bytes 로드 실패
+/// - [`SerializeError::PageOutOfBounds`] — source.page_index가 원본 페이지 수 초과
+/// - [`SerializeError::Save`] — lopdf save_to 실패
+pub fn serialize_document(
+    doc: &Document,
+    sources: &[PageSource],
+) -> Result<Vec<u8>, SerializeError> {
+    // 1. pages 비어있으면 즉시 에러
+    if doc.pages.is_empty() {
+        return Err(SerializeError::EmptyDocument);
+    }
+
+    // 2. sources.len() != pages.len() → SourceLengthMismatch
+    if sources.len() != doc.pages.len() {
+        return Err(SerializeError::SourceLengthMismatch {
+            sources: sources.len(),
+            pages: doc.pages.len(),
+        });
+    }
+
+    // 3. 소스 그룹핑: Arc 포인터로 동일 소스 식별
+    // 첫 번째 소스 기준으로, 다른 포인터가 하나라도 있으면 다중 소스
+    let is_multi_source = sources
+        .iter()
+        .any(|s| !Arc::ptr_eq(&s.bytes, &sources[0].bytes));
+
+    if is_multi_source {
+        serialize_multi_source(doc, sources)
+    } else {
+        serialize_single_source(doc, sources)
+    }
+}
+
+/// 단일 소스 경로: 모든 sources[i].bytes가 동일한 Arc 포인터를 가리키는 경우.
+fn serialize_single_source(
+    doc: &Document,
+    sources: &[PageSource],
+) -> Result<Vec<u8>, SerializeError> {
+    let bytes = &sources[0].bytes;
+
+    // 4a. lopdf로 로드
+    let mut lopdf_doc = lopdf::Document::load_mem(bytes).map_err(SerializeError::LoadSource)?;
+
+    // 4b. 삭제 전에 page_oid_map 구성 (ObjectId는 delete 후에도 변경되지 않음)
+    // lopdf.get_pages() → BTreeMap<u32, ObjectId> (u32: 1-based)
+    let lopdf_pages: BTreeMap<u32, lopdf::ObjectId> = lopdf_doc.get_pages();
+    let total_page_count = lopdf_pages.len();
+
+    // src_page_index(0-based) → ObjectId 매핑
+    let page_oid_map: HashMap<usize, lopdf::ObjectId> = lopdf_pages
+        .into_iter()
+        .map(|(one_based, oid)| ((one_based - 1) as usize, oid))
+        .collect();
+
+    // 4b. PageOutOfBounds 검증
+    for source in sources {
+        if source.page_index >= total_page_count {
+            return Err(SerializeError::PageOutOfBounds {
+                idx: source.page_index,
+                count: total_page_count,
+            });
+        }
+    }
+
+    // 4c. 유지할 원본 페이지 번호(1-based) 집합
+    let keep_set: HashSet<u32> = sources.iter().map(|s| (s.page_index + 1) as u32).collect();
+
+    // 4d. 삭제할 페이지 번호(1-based) 목록
+    let delete_list: Vec<u32> = (1..=(total_page_count as u32))
+        .filter(|n| !keep_set.contains(n))
+        .collect();
+
+    // 4e. 페이지 삭제
+    if !delete_list.is_empty() {
+        lopdf_doc.delete_pages(&delete_list);
+    }
+
+    // 4f. rotation 항상 적용 (rotation == 0이어도 /Rotate 0을 명시적으로 설정)
+    // ObjectId는 delete_pages 후에도 변경되지 않으므로 pre-build 매핑 재사용 가능
+    apply_rotation(doc, sources, &page_oid_map, &mut lopdf_doc);
+
+    // 4g. 직렬화
+    save_to_vec(lopdf_doc)
+}
+
+/// 다중 소스 경로: Arc 포인터가 다른 sources가 있는 경우 (MergeCommand 결과).
+///
+/// lopdf 공식 merge 예제 패턴을 따른다:
+/// 1. 각 소스 Document를 renumber_objects_with로 ID 충돌 방지
+/// 2. 모든 objects를 수집 (Catalog/Pages는 특별 처리)
+/// 3. 통합 Catalog/Pages 구성 + 각 Page에 Parent 설정
+/// 4. 단일 lopdf Document로 저장
+fn serialize_multi_source(
+    doc: &Document,
+    sources: &[PageSource],
+) -> Result<Vec<u8>, SerializeError> {
+    // a. 소스별로 고유한 Arc 포인터 목록 수집 (순서 보존)
+    let mut seen_ptrs: Vec<*const Vec<u8>> = Vec::new();
+    let mut unique_arcs: Vec<Arc<Vec<u8>>> = Vec::new();
+    for source in sources {
+        let ptr = Arc::as_ptr(&source.bytes);
+        if !seen_ptrs.contains(&ptr) {
+            seen_ptrs.push(ptr);
+            unique_arcs.push(Arc::clone(&source.bytes));
+        }
+    }
+
+    // b. 각 고유 소스별 lopdf Document 로드 + page ObjectId 매핑 구성
+    struct SourceEntry {
+        lopdf_doc: lopdf::Document,
+        /// 0-based page_index → ObjectId (renumber 후 갱신됨)
+        page_oid_map: HashMap<usize, lopdf::ObjectId>,
+        total_pages: usize,
+    }
+
+    let mut entries: Vec<(*const Vec<u8>, SourceEntry)> = Vec::new();
+    for arc_bytes in &unique_arcs {
+        let lopdf_doc = lopdf::Document::load_mem(arc_bytes).map_err(SerializeError::LoadSource)?;
+
+        let lopdf_pages: BTreeMap<u32, lopdf::ObjectId> = lopdf_doc.get_pages();
+        let total_pages = lopdf_pages.len();
+        let page_oid_map: HashMap<usize, lopdf::ObjectId> = lopdf_pages
+            .into_iter()
+            .map(|(one_based, oid)| ((one_based - 1) as usize, oid))
+            .collect();
+
+        entries.push((
+            Arc::as_ptr(arc_bytes),
+            SourceEntry {
+                lopdf_doc,
+                page_oid_map,
+                total_pages,
+            },
+        ));
+    }
+
+    // PageOutOfBounds 검증
+    for source in sources {
+        let ptr = Arc::as_ptr(&source.bytes);
+        if let Some((_, entry)) = entries.iter().find(|(p, _)| *p == ptr)
+            && source.page_index >= entry.total_pages
+        {
+            return Err(SerializeError::PageOutOfBounds {
+                idx: source.page_index,
+                count: entry.total_pages,
+            });
+        }
+    }
+
+    // c. renumber_objects_with로 ID 충돌 방지
+    // 첫 번째 소스의 max_id 이후부터 두 번째 소스 ID 시작
+    // renumber 후 ObjectId가 변경되므로 page_oid_map을 반드시 재계산한다.
+    let mut max_id = entries[0].1.lopdf_doc.max_id;
+    for (_, entry) in entries.iter_mut().skip(1) {
+        entry.lopdf_doc.renumber_objects_with(max_id + 1);
+        max_id = entry.lopdf_doc.max_id;
+
+        // renumber 후 ObjectId 변경 → 매핑 재계산
+        let new_pages: BTreeMap<u32, lopdf::ObjectId> = entry.lopdf_doc.get_pages();
+        entry.page_oid_map = new_pages
+            .into_iter()
+            .map(|(one_based, oid)| ((one_based - 1) as usize, oid))
+            .collect();
+    }
+
+    // d. 결과 Document 구성 (lopdf 공식 merge 패턴)
+    // 첫 번째 소스의 버전을 사용해 새 Document 생성
+    let pdf_version = entries[0].1.lopdf_doc.version.clone();
+    let mut merged = lopdf::Document::with_version(pdf_version);
+
+    // doc.pages 순서대로 유지할 Page ObjectId 목록 구성
+    // 각 source.page_index → 해당 소스의 renumber된 ObjectId
+    let ordered_page_ids: Vec<lopdf::ObjectId> = sources
+        .iter()
+        .map(|source| {
+            let ptr = Arc::as_ptr(&source.bytes);
+            let (_, entry) = entries.iter().find(|(p, _)| *p == ptr).unwrap();
+            *entry.page_oid_map.get(&source.page_index).unwrap()
+        })
+        .collect();
+
+    // e. 모든 소스의 objects를 merged에 수집
+    // Catalog, Pages 타입은 스킵하고 별도 처리
+    // Page 타입은 그대로 수집 (Parent는 나중에 업데이트)
+    let mut catalog_obj: Option<(lopdf::ObjectId, lopdf::Object)> = None;
+    let mut pages_obj: Option<(lopdf::ObjectId, lopdf::Object)> = None;
+
+    for (_, entry) in &entries {
+        for (oid, obj) in &entry.lopdf_doc.objects {
+            let type_name = obj.type_name().unwrap_or(b"");
+            match type_name {
+                b"Catalog" => {
+                    // 첫 번째 Catalog만 유지
+                    if catalog_obj.is_none() {
+                        catalog_obj = Some((*oid, obj.clone()));
+                    }
+                }
+                b"Pages" => {
+                    // 첫 번째 Pages만 유지 (Kids, Count는 나중에 재구성)
+                    if pages_obj.is_none() {
+                        pages_obj = Some((*oid, obj.clone()));
+                    }
+                }
+                b"Outlines" | b"Outline" => {
+                    // Merge 시 Outlines 미지원 (v0.3 알려진 한계)
+                }
+                _ => {
+                    merged.objects.insert(*oid, obj.clone());
+                }
+            }
+        }
+    }
+
+    let (catalog_id, catalog_object) = catalog_obj.ok_or_else(|| {
+        SerializeError::Save(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "no Catalog found in source documents",
+        ))
+    })?;
+    let (pages_id, pages_object) = pages_obj.ok_or_else(|| {
+        SerializeError::Save(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "no Pages root found in source documents",
+        ))
+    })?;
+
+    // f. 각 Page에 Parent를 통합 pages_id로 설정
+    for page_oid in &ordered_page_ids {
+        if let Some(lopdf::Object::Dictionary(dict)) = merged.objects.get_mut(page_oid) {
+            dict.set("Parent", lopdf::Object::Reference(pages_id));
+        }
+    }
+
+    // g. Pages 딕셔너리 재구성: /Kids, /Count 업데이트
+    if let lopdf::Object::Dictionary(mut pages_dict) = pages_object {
+        let kids: Vec<lopdf::Object> = ordered_page_ids
+            .iter()
+            .map(|&oid| lopdf::Object::Reference(oid))
+            .collect();
+        pages_dict.set("Kids", lopdf::Object::Array(kids));
+        pages_dict.set(
+            "Count",
+            lopdf::Object::Integer(ordered_page_ids.len() as i64),
+        );
+        // Outlines 제거 (merge 시 미지원)
+        pages_dict.remove(b"Outlines");
+        merged
+            .objects
+            .insert(pages_id, lopdf::Object::Dictionary(pages_dict));
+    }
+
+    // h. Catalog 삽입 + trailer /Root 설정
+    if let lopdf::Object::Dictionary(mut cat_dict) = catalog_object {
+        cat_dict.set("Pages", lopdf::Object::Reference(pages_id));
+        cat_dict.remove(b"Outlines");
+        merged
+            .objects
+            .insert(catalog_id, lopdf::Object::Dictionary(cat_dict));
+    }
+    merged
+        .trailer
+        .set("Root", lopdf::Object::Reference(catalog_id));
+
+    // i. max_id 갱신 + renumber
+    merged.max_id = merged.objects.len() as u32;
+    merged.renumber_objects();
+
+    // j. renumber 후 페이지 ObjectId 매핑 재계산 (rotation 적용을 위해)
+    let renumbered_pages: BTreeMap<u32, lopdf::ObjectId> = merged.get_pages();
+    // renumber 후 페이지 순서 보존: ordered_page_ids의 순서가 get_pages() 순서와 일치해야 한다.
+    // get_pages()는 1-based 순서로 반환하므로 doc.pages 순서와 대응
+    let renumbered_oids: Vec<lopdf::ObjectId> = renumbered_pages.values().cloned().collect();
+
+    // k. rotation 항상 적용
+    for (i, page) in doc.pages.iter().enumerate() {
+        if let Some(&oid) = renumbered_oids.get(i) {
+            set_rotation(&mut merged, oid, page.rotation);
+        }
+    }
+
+    // l. 직렬화
+    save_to_vec(merged)
+}
+
+/// 단일 page object의 /Rotate 값을 설정한다.
+///
+/// rotation == 0이어도 반드시 /Rotate 0을 명시적으로 설정한다.
+/// 원본이 /Rotate 90이었다가 0으로 복원하는 경우를 처리하기 위함.
+fn set_rotation(lopdf_doc: &mut lopdf::Document, oid: lopdf::ObjectId, rotation: i32) {
+    if let Ok(lopdf::Object::Dictionary(dict)) = lopdf_doc.get_object_mut(oid) {
+        dict.set("Rotate", lopdf::Object::Integer(rotation as i64));
+    }
+}
+
+/// doc.pages와 sources를 zip하여 각 페이지 ObjectId에 rotation을 적용한다.
+fn apply_rotation(
+    doc: &Document,
+    sources: &[PageSource],
+    page_oid_map: &HashMap<usize, lopdf::ObjectId>,
+    lopdf_doc: &mut lopdf::Document,
+) {
+    for (page, source) in doc.pages.iter().zip(sources.iter()) {
+        if let Some(&oid) = page_oid_map.get(&source.page_index) {
+            set_rotation(lopdf_doc, oid, page.rotation);
+        }
+    }
+}
+
+/// lopdf Document를 Vec<u8>으로 직렬화한다.
+fn save_to_vec(mut lopdf_doc: lopdf::Document) -> Result<Vec<u8>, SerializeError> {
+    let mut out = Vec::new();
+    lopdf_doc.save_to(&mut out)?;
+    Ok(out)
+}

--- a/crates/rpdf-serializer/src/types.rs
+++ b/crates/rpdf-serializer/src/types.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+/// 단일 페이지의 원본 PDF 출처를 기록하는 직렬화 힌트.
+///
+/// `load_document_tracked`가 반환하는 `Vec<PageSource>`는
+/// `Document.pages`와 1:1 대응한다: `sources[i]` → `pages[i]`.
+///
+/// 커맨드 실행 후 호출자가 `sources`를 `doc.pages`와 동기화할 책임을 진다.
+/// - `RotatePageCommand`: 변경 없음 (page 순서 동일)
+/// - `DeletePagesCommand(indices: [1, 3])`: `[s0, s2, s4]` — 삭제 인덱스 제거
+/// - `ExtractPagesCommand(1-5)`: `sources[0..=4]` — 범위 슬라이스
+/// - `SplitCommand`: 각 결과 doc의 page 원본 인덱스로 sources 슬라이스
+/// - `MergeCommand`: `a_sources + b_sources + ...` 순서로 연결
+pub struct PageSource {
+    /// 원본 PDF 바이트. 동일한 파일에서 로드된 여러 PageSource는 같은 Arc를 공유한다.
+    pub bytes: Arc<Vec<u8>>,
+    /// 원본 PDF에서의 0-based 페이지 인덱스.
+    pub page_index: usize,
+}

--- a/crates/rpdf-serializer/tests/serialize_tests.rs
+++ b/crates/rpdf-serializer/tests/serialize_tests.rs
@@ -258,7 +258,7 @@ fn serialize_after_merge() {
 
     // sources 동기화: a_sources + b_sources 순서로 연결
     let merged_sources: Vec<PageSource> =
-        sources_a.into_iter().chain(sources_b.into_iter()).collect();
+        sources_a.into_iter().chain(sources_b).collect();
     assert_eq!(merged_sources.len(), 5);
 
     let out = serialize_document(&doc_a, &merged_sources).unwrap();

--- a/crates/rpdf-serializer/tests/serialize_tests.rs
+++ b/crates/rpdf-serializer/tests/serialize_tests.rs
@@ -1,0 +1,271 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use rpdf_edit::commands::{
+    Command, DeletePagesCommand, ExtractPagesCommand, MergeCommand, Query, RotatePageCommand,
+    SplitCommand,
+};
+use rpdf_serializer::{PageSource, SerializeError, load_document_tracked, serialize_document};
+
+/// 테스트 픽스처 파일을 읽어 바이트로 반환한다.
+fn fixture(name: &str) -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples")
+        .join(name);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("fixture {} 읽기 실패: {}", name, e))
+}
+
+// --- CP-B: 에러 테스트 ---
+
+#[test]
+fn serialize_empty_doc_error() {
+    use rpdf_core::types::document::Document;
+
+    let doc = Document {
+        pages: vec![],
+        metadata: None,
+    };
+    let sources: Vec<PageSource> = vec![];
+    let err = serialize_document(&doc, &sources).unwrap_err();
+    assert!(matches!(err, SerializeError::EmptyDocument), "got: {err}");
+}
+
+#[test]
+fn serialize_source_length_mismatch_error() {
+    let bytes = fixture("pdfjs-basicapi.pdf");
+    let (doc, sources) = load_document_tracked(&bytes).unwrap();
+    assert_eq!(doc.pages.len(), 3);
+
+    // sources를 2개만 전달 (pages는 3개)
+    let truncated: Vec<PageSource> = sources.into_iter().take(2).collect();
+    let err = serialize_document(&doc, &truncated).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            SerializeError::SourceLengthMismatch {
+                sources: 2,
+                pages: 3
+            }
+        ),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn serialize_page_out_of_bounds_error() {
+    let bytes = fixture("pdfjs-basicapi.pdf");
+    let (doc, _) = load_document_tracked(&bytes).unwrap();
+    assert_eq!(doc.pages.len(), 3);
+
+    // page_index가 원본 페이지 수(3)를 초과하는 PageSource 수동 구성
+    let fake_source = PageSource {
+        bytes: Arc::new(bytes),
+        page_index: 99, // out of bounds
+    };
+    let sources = vec![fake_source];
+
+    // doc을 1페이지짜리로 만들어야 SourceLengthMismatch를 피함
+    use rpdf_core::types::document::{Document, Page};
+    let single_page_doc = Document {
+        pages: vec![Page {
+            index: 0,
+            content: vec![],
+            resources: None,
+            media_box: None,
+            crop_box: None,
+            rotation: 0,
+        }],
+        metadata: None,
+    };
+    let err = serialize_document(&single_page_doc, &sources).unwrap_err();
+    assert!(
+        matches!(err, SerializeError::PageOutOfBounds { idx: 99, .. }),
+        "got: {err}"
+    );
+}
+
+// --- CP-C: roundtrip + rotation 테스트 ---
+
+#[test]
+fn serialize_basic_roundtrip() {
+    // pdfjs-basicapi.pdf: 3페이지
+    let bytes = fixture("pdfjs-basicapi.pdf");
+    let (doc, sources) = load_document_tracked(&bytes).unwrap();
+    assert_eq!(doc.pages.len(), 3, "픽스처는 3페이지여야 한다");
+
+    let out = serialize_document(&doc, &sources).unwrap();
+    assert!(!out.is_empty(), "직렬화 결과가 비어있으면 안 됨");
+
+    // re-parse
+    let (doc2, _) = load_document_tracked(&out).unwrap();
+    assert_eq!(doc2.pages.len(), 3, "re-parse 후 페이지 수 동일해야 한다");
+}
+
+#[test]
+fn serialize_after_rotate() {
+    // 0→90 rotation 후 serialize → re-parse → rotation == 90
+    let bytes = fixture("pdfjs-basicapi.pdf");
+    let (mut doc, sources) = load_document_tracked(&bytes).unwrap();
+
+    let cmd = RotatePageCommand::new(0, 90);
+    cmd.execute(&mut doc).unwrap();
+    assert_eq!(doc.pages[0].rotation, 90);
+
+    let out = serialize_document(&doc, &sources).unwrap();
+    let (doc2, _) = load_document_tracked(&out).unwrap();
+    assert_eq!(
+        doc2.pages[0].rotation, 90,
+        "re-parse 후 rotation == 90이어야 한다"
+    );
+}
+
+#[test]
+fn serialize_after_rotate_to_zero() {
+    // rotation 90→0 후 serialize → re-parse → rotation == 0
+    // D4: rotation == 0이어도 /Rotate 0을 명시적으로 설정하는 경로 검증
+    let bytes = fixture("pdfjs-basicapi.pdf");
+    let (mut doc, sources) = load_document_tracked(&bytes).unwrap();
+
+    // 먼저 90도로 설정
+    let cmd_90 = RotatePageCommand::new(0, 90);
+    cmd_90.execute(&mut doc).unwrap();
+    assert_eq!(doc.pages[0].rotation, 90);
+
+    let out_90 = serialize_document(&doc, &sources).unwrap();
+    let (doc_90, sources_90) = load_document_tracked(&out_90).unwrap();
+    assert_eq!(doc_90.pages[0].rotation, 90);
+
+    // 다시 90도 추가 회전 → 총 180도
+    // 또는 명시적으로 rotation을 0으로 설정해 re-serialize
+    // 계획서 D4: "수동으로 page.rotation=0인 Page 구성 후 serialize"
+    let mut doc_zero = doc_90;
+    doc_zero.pages[0].rotation = 0;
+
+    let out_zero = serialize_document(&doc_zero, &sources_90).unwrap();
+    let (doc_re, _) = load_document_tracked(&out_zero).unwrap();
+    assert_eq!(
+        doc_re.pages[0].rotation, 0,
+        "re-parse 후 rotation == 0이어야 한다 (rotation=0도 명시적으로 덮어씀)"
+    );
+}
+
+// --- CP-D: delete/extract/split 테스트 ---
+
+#[test]
+fn serialize_after_delete() {
+    // pdfjs-basicapi.pdf: 3페이지 → 1페이지 삭제 → 2페이지
+    let bytes = fixture("pdfjs-basicapi.pdf");
+    let (mut doc, mut sources) = load_document_tracked(&bytes).unwrap();
+    assert_eq!(doc.pages.len(), 3);
+
+    // 0-based index 1 삭제
+    let cmd = DeletePagesCommand::new(vec![1]);
+    cmd.execute(&mut doc).unwrap();
+    assert_eq!(doc.pages.len(), 2);
+
+    // sources 동기화: index 1 제거
+    sources.remove(1);
+    assert_eq!(sources.len(), 2);
+
+    let out = serialize_document(&doc, &sources).unwrap();
+    let (doc2, _) = load_document_tracked(&out).unwrap();
+    assert_eq!(doc2.pages.len(), 2, "삭제 후 re-parse 페이지 수 == 2");
+}
+
+#[test]
+fn serialize_after_extract() {
+    // fw4-2024.pdf: 5페이지 → 1-3 extract → 3페이지
+    let bytes = fixture("fw4-2024.pdf");
+    let (doc, sources) = load_document_tracked(&bytes).unwrap();
+    assert_eq!(doc.pages.len(), 5, "fw4-2024.pdf는 5페이지여야 한다");
+
+    let cmd = ExtractPagesCommand::new(1, 3).unwrap();
+    let extracted_doc = cmd.execute(&doc).unwrap();
+    assert_eq!(extracted_doc.pages.len(), 3);
+
+    // sources 동기화: pages[0..=2]에 해당하는 sources[0..=2]
+    let extracted_sources: Vec<PageSource> = sources.into_iter().take(3).collect();
+    assert_eq!(extracted_sources.len(), 3);
+
+    let out = serialize_document(&extracted_doc, &extracted_sources).unwrap();
+    let (doc2, _) = load_document_tracked(&out).unwrap();
+    assert_eq!(doc2.pages.len(), 3, "extract 후 re-parse 페이지 수 == 3");
+}
+
+#[test]
+fn serialize_after_split() {
+    // fw4-2024.pdf: 5페이지 → "1-2,3-5" split → [2p, 3p]
+    let bytes = fixture("fw4-2024.pdf");
+    let (doc, sources) = load_document_tracked(&bytes).unwrap();
+    assert_eq!(doc.pages.len(), 5);
+
+    let cmd = SplitCommand::new("1-2,3-5").unwrap();
+    let split_docs = cmd.execute(&doc).unwrap();
+    assert_eq!(split_docs.len(), 2);
+    assert_eq!(split_docs[0].pages.len(), 2);
+    assert_eq!(split_docs[1].pages.len(), 3);
+
+    // 각 split doc의 sources 동기화
+    // split_docs[0]: 원본 pages[0..=1] → sources[0..=1]
+    // split_docs[1]: 원본 pages[2..=4] → sources[2..=4]
+    let sources0: Vec<PageSource> = sources
+        .iter()
+        .take(2)
+        .map(|s| PageSource {
+            bytes: Arc::clone(&s.bytes),
+            page_index: s.page_index,
+        })
+        .collect();
+    let sources1: Vec<PageSource> = sources
+        .iter()
+        .skip(2)
+        .map(|s| PageSource {
+            bytes: Arc::clone(&s.bytes),
+            page_index: s.page_index,
+        })
+        .collect();
+
+    let out0 = serialize_document(&split_docs[0], &sources0).unwrap();
+    let (doc_a, _) = load_document_tracked(&out0).unwrap();
+    assert_eq!(doc_a.pages.len(), 2, "split[0] re-parse 페이지 수 == 2");
+
+    let out1 = serialize_document(&split_docs[1], &sources1).unwrap();
+    let (doc_b, _) = load_document_tracked(&out1).unwrap();
+    assert_eq!(doc_b.pages.len(), 3, "split[1] re-parse 페이지 수 == 3");
+}
+
+// --- CP-E: merge 다중 소스 테스트 ---
+
+#[test]
+fn serialize_after_merge() {
+    // irs-f1040.pdf (2페이지) + pdfjs-basicapi.pdf (3페이지) = 5페이지
+    let bytes_a = fixture("irs-f1040.pdf");
+    let bytes_b = fixture("pdfjs-basicapi.pdf");
+
+    let (mut doc_a, sources_a) = load_document_tracked(&bytes_a).unwrap();
+    let (doc_b, sources_b) = load_document_tracked(&bytes_b).unwrap();
+
+    assert_eq!(doc_a.pages.len(), 2, "irs-f1040.pdf는 2페이지여야 한다");
+    assert_eq!(
+        doc_b.pages.len(),
+        3,
+        "pdfjs-basicapi.pdf는 3페이지여야 한다"
+    );
+
+    let cmd = MergeCommand::new(vec![doc_b.clone()]);
+    cmd.execute(&mut doc_a).unwrap();
+    assert_eq!(doc_a.pages.len(), 5);
+
+    // sources 동기화: a_sources + b_sources 순서로 연결
+    let merged_sources: Vec<PageSource> =
+        sources_a.into_iter().chain(sources_b.into_iter()).collect();
+    assert_eq!(merged_sources.len(), 5);
+
+    let out = serialize_document(&doc_a, &merged_sources).unwrap();
+    let (doc_merged, _) = load_document_tracked(&out).unwrap();
+    assert_eq!(
+        doc_merged.pages.len(),
+        5,
+        "merge 후 re-parse 페이지 수 == 5"
+    );
+}

--- a/crates/rpdf-serializer/tests/serialize_tests.rs
+++ b/crates/rpdf-serializer/tests/serialize_tests.rs
@@ -257,8 +257,7 @@ fn serialize_after_merge() {
     assert_eq!(doc_a.pages.len(), 5);
 
     // sources 동기화: a_sources + b_sources 순서로 연결
-    let merged_sources: Vec<PageSource> =
-        sources_a.into_iter().chain(sources_b).collect();
+    let merged_sources: Vec<PageSource> = sources_a.into_iter().chain(sources_b).collect();
     assert_eq!(merged_sources.len(), 5);
 
     let out = serialize_document(&doc_a, &merged_sources).unwrap();

--- a/mydocs/plans/task23-serializer.md
+++ b/mydocs/plans/task23-serializer.md
@@ -1,0 +1,344 @@
+# Task #23: Serializer 구현 (Document → PDF 저장)
+
+**이슈**: #44  
+**브랜치**: `local/task23`  
+**마일스톤**: v0.3
+
+---
+
+## 목적 및 배경
+
+Task #17~#22에서 5개 편집 커맨드(Rotate/Delete/Merge/Split/Extract)를 구현했으나,
+편집 결과를 PDF 파일로 저장하는 수단이 없다. 이 작업은 `Document` IR을 유효한 PDF
+바이트로 직렬화하는 `rpdf-serializer` 크레이트를 구현한다.
+
+### 핵심 설계 결정: lopdf 백엔드 + source tracking 분리 (plan-eng-review 반영)
+
+현재 `Document` IR은 논리적 페이지 구조만 보유하며, 페이지가 참조하는 embedded 객체
+(폰트, 이미지, ICC 프로파일 등)를 포함하지 않는다. 이 객체들을 재구성하는 것은
+v0.3 범위를 벗어나므로, **lopdf를 serialization 백엔드**로 사용한다.
+
+**결정 사항 (plan-eng-review):**
+- `rpdf-core` 변경 없음 — 직렬화 관심사를 도메인 타입에 오염하지 않는다.
+- `rpdf-parser` 변경 없음 — 파싱 API는 기존 그대로.
+- `rpdf-serializer`가 `PageSource` 추적 + lopdf 조작을 모두 담당한다.
+- 호출자(CLI)가 `Vec<PageSource>`를 `doc.pages`와 동기화할 책임을 진다.
+
+공개 API 확인: lopdf 0.40.0 (`Document::load_mem`, `save_to`, `get_pages`,
+`delete_pages`, `get_object_mut`, `renumber_objects_with`) — docs.rs 확인 완료.
+
+---
+
+## API 설계
+
+### rpdf-serializer (신규 크레이트)
+
+**Cargo.toml**:
+```toml
+[package]
+name = "rpdf-serializer"
+version = "0.1.0"
+
+[dependencies]
+rpdf-core.workspace = true
+rpdf-parser.workspace = true
+lopdf = "0.40.0"
+thiserror.workspace = true
+```
+
+**타입 및 공개 API**:
+```rust
+use std::sync::Arc;
+
+/// 단일 페이지의 원본 PDF 출처를 기록하는 직렬화 힌트.
+///
+/// load_document_tracked()가 반환하는 Vec<PageSource>는
+/// Document.pages와 1:1 대응한다: sources[i] → pages[i].
+pub struct PageSource {
+    /// 원본 PDF 바이트.
+    pub bytes: Arc<Vec<u8>>,
+    /// 원본 PDF에서의 0-based 페이지 인덱스.
+    pub page_index: usize,
+}
+
+/// PDF 바이트에서 Document와 PageSource 목록을 함께 반환한다.
+///
+/// Document.pages[i]에 대응하는 원본 출처가 sources[i]에 담겨있다.
+/// 커맨드 실행 후에는 호출자가 sources를 pages와 동기화해야 한다.
+pub fn load_document_tracked(
+    data: &[u8],
+) -> Result<(Document, Vec<PageSource>), ParseError>;
+
+/// Document IR을 PDF 바이트로 직렬화한다.
+///
+/// `sources[i]`는 `doc.pages[i]`의 원본 출처여야 한다.
+/// `sources.len() != doc.pages.len()` 이면 에러를 반환한다.
+///
+/// # Errors
+///
+/// - [`SerializeError::EmptyDocument`] — pages가 비어있음
+/// - [`SerializeError::SourceLengthMismatch`] — sources와 pages 개수 불일치
+/// - [`SerializeError::LoadSource`] — lopdf가 source_bytes 로드 실패
+/// - [`SerializeError::PageOutOfBounds`] — source.page_index가 원본 페이지 수 초과
+/// - [`SerializeError::Save`] — lopdf save_to 실패
+pub fn serialize_document(
+    doc: &Document,
+    sources: &[PageSource],
+) -> Result<Vec<u8>, SerializeError>;
+
+/// 에러 타입
+#[derive(Debug, thiserror::Error)]
+pub enum SerializeError {
+    #[error("document has no pages")]
+    EmptyDocument,
+    #[error("sources length {sources} != pages length {pages}")]
+    SourceLengthMismatch { sources: usize, pages: usize },
+    #[error("failed to load source PDF (lopdf incompatible): {0}")]
+    LoadSource(lopdf::Error),
+    #[error("source_page_index {idx} out of bounds (source has {count} pages)")]
+    PageOutOfBounds { idx: usize, count: usize },
+    #[error("lopdf save failed: {0}")]
+    Save(#[from] std::io::Error),
+}
+```
+
+### 호출자의 sources 동기화 책임
+
+커맨드 실행 후 호출자는 `sources`를 `doc.pages`와 동기화해야 한다.
+
+| 커맨드 | sources 처리 |
+|--------|-------------|
+| RotatePageCommand | 변경 없음 (page 순서 동일) |
+| DeletePagesCommand (0-based idx: [1, 3]) | `[s0, s2, s4]` — 삭제 인덱스 제거 |
+| ExtractPagesCommand (1-5페이지 extract) | `sources[0..=4]` — 범위 슬라이스 |
+| SplitCommand (결과 docs 여러 개) | 각 결과 doc의 page.index로 sources 슬라이스 |
+| MergeCommand (target + source들) | a_sources + b_sources + ... 순서로 연결 |
+
+---
+
+## 알고리즘 설계
+
+### load_document_tracked
+
+```
+fn load_document_tracked(data: &[u8]) -> Result<(Document, Vec<PageSource>), ParseError>
+    let doc = load_document(data)?          // rpdf-parser
+    let bytes_arc = Arc::new(data.to_vec()) // 한 번만 clone
+    let sources = doc.pages.iter()
+        .map(|p| PageSource { bytes: Arc::clone(&bytes_arc), page_index: p.index })
+        .collect()
+    Ok((doc, sources))
+```
+
+### serialize_document — 단일 소스 경로
+
+모든 `sources[i].bytes`가 동일한 Arc 포인터를 가리키는 경우.
+
+```
+fn serialize_document(doc, sources) -> Result<Vec<u8>, SerializeError>
+
+1. doc.pages 비어있으면 → EmptyDocument
+2. sources.len() != doc.pages.len() → SourceLengthMismatch
+3. 소스 그룹핑: Arc 포인터로 동일 소스 식별
+   → groups: Vec<(Arc<Vec<u8>>, Vec<(out_pos, src_page_idx)>)>
+
+4. [단일 소스]
+   a. lopdf::Document::load_mem(&bytes) → lopdf_doc
+      실패 시 → LoadSource (메시지: "lopdf incompatible")
+   b. page_oid_map 구성 (삭제 전):
+      lopdf_doc.get_pages() → BTreeMap<u32, ObjectId>
+      → HashMap<usize(src_page_idx), ObjectId>
+   c. 유지할 원본 페이지 번호 = { source.page_index + 1 | source ∈ sources }
+   d. 삭제할 번호 = 전체 페이지 번호 집합 - 유지 집합
+   e. lopdf_doc.delete_pages(&delete_list)
+   f. [rotation 항상 적용 — D2 수정]
+      for (page, source) in doc.pages.iter().zip(sources.iter()):
+          let oid = page_oid_map[source.page_index]
+          let page_obj = lopdf_doc.get_object_mut(oid)?
+          if let Dictionary(ref mut dict) = page_obj:
+              dict.set("Rotate", Object::Integer(page.rotation as i64))
+              // rotation == 0이어도 반드시 쓴다
+   g. out = Vec::new()
+      lopdf_doc.save_to(&mut out) → Save 에러
+   h. return Ok(out)
+```
+
+### serialize_document — 다중 소스 경로 (D3 추가)
+
+```
+4. [다중 소스 — MergeCommand 결과]
+   a. 각 소스 그룹별 lopdf::Document::load_mem() 로드
+      → lopdf_docs: Vec<(Arc<Vec<u8>>, lopdf::Document)>
+
+   b. max_id 추적 변수 (처음엔 첫 번째 소스의 max object id)
+      lopdf_docs[0].get_object_id_count() 또는
+      *lopdf_docs[0].objects.keys().max().unwrap() 사용
+
+   c. 두 번째 소스부터:
+      lopdf_doc.renumber_objects_with(max_id + 1)
+      max_id = 새 max object id
+
+   d. 첫 번째 소스를 base로:
+      base = lopdf_docs[0]
+      for doc in lopdf_docs[1..]:
+          for (oid, obj) in doc.objects.iter():
+              base.objects.insert(*oid, obj.clone())
+
+   e. base의 페이지 트리 재구성:
+      final_kids: Vec<ObjectId> = doc.pages 순서대로
+          sources[i].page_index → 해당 소스 lopdf_doc의 page ObjectId
+          (renumber 후 ObjectId 매핑 유지 필요 → step b에서 매핑 테이블 구성)
+      base의 /Pages 딕셔너리 /Kids 배열 = final_kids
+      base의 /Pages /Count = final_kids.len()
+
+   f. rotation 항상 적용 (단일 소스와 동일)
+
+   g. base.save_to(&mut out)
+```
+
+---
+
+## 에러 표 ↔ 로직 교차 검증
+
+| 에러 변형 | 로직 발생 지점 |
+|-----------|--------------|
+| `EmptyDocument` | 1. (pages 비어있음 즉시) |
+| `SourceLengthMismatch` | 2. (len 체크) |
+| `LoadSource` | 4a, 다중 소스 a (lopdf load_mem 실패) |
+| `PageOutOfBounds` | 4b, 다중 소스 e (source.page_index 유효성 검사) |
+| `Save` | 4h, 다중 소스 g (save_to 실패) |
+
+모든 에러 변형에 대응하는 로직 경로 존재 — 교차 검증 완료.
+
+---
+
+## 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| 0-page document | `EmptyDocument` 에러 |
+| sources.len() != pages.len() | `SourceLengthMismatch` 에러 |
+| source.page_index >= 원본 페이지 수 | `PageOutOfBounds` 에러 |
+| rotation == 0 (원본이 /Rotate 90이었다가 0으로 복원) | 항상 0으로 덮어씀 — D2 수정 |
+| 단일 페이지 PDF에서 extract | 삭제 없이 그대로 저장 |
+| 역순 페이지 정렬 | v0.3 scope-out 참조 |
+
+---
+
+## v0.3 알려진 한계 (D5, D6 반영)
+
+| 한계 | 설명 |
+|------|------|
+| 이중 파서 비호환 리스크 | rpdf-parser가 허용한 PDF를 lopdf가 거부하면 `LoadSource` 에러 발생. `LoadSource` 에러 메시지: "failed to load source PDF (lopdf incompatible)". 사용자는 원본 PDF 문제임을 명확히 인지 가능. |
+| Merge 시 PDF 구조 유실 | Outlines(북마크), AcroForms(폼 데이터), Named Destinations 등 전역 구조가 유실될 수 있다. v0.4에서 보완. |
+| O(N²) Split 성능 | 대량 페이지 split 시 각 Document 직렬화마다 lopdf::load_mem 호출. 동일 소스 Document를 일괄 직렬화하거나 외부 캐싱으로 완화 가능. v0.3 CLI 사용 범위에서는 허용 수준. |
+| 역순 페이지 재정렬 | doc.pages 순서가 원본 오름차순과 다른 경우 미지원. v0.4 이후 Pages Kids 재구성으로 해결 예정. |
+| synthesized Page 직렬화 | source_bytes 없이 동적으로 생성된 Page 직렬화 불가. |
+| 암호화 PDF 저장 | 미지원. |
+| incremental update 모드 | 미지원 (full rewrite만). |
+
+---
+
+## 테스트 전략
+
+### 단위 테스트 (`crates/rpdf-serializer/tests/`)
+
+기존 `samples/` 및 `examples/` 픽스처 활용 — 신규 fixture 불필요.
+**테스트 전 `rpdf info <file>`로 페이지 수 확인 필수.**
+
+| # | 테스트명 | 검증 | Fixture |
+|---|---------|------|---------|
+| 1 | `serialize_basic_roundtrip` | parse → serialize → re-parse → page count 동일 | examples/pdfjs-basicapi.pdf (3p) |
+| 2 | `serialize_after_rotate` | rotation 0→90 후 re-parse → rotation == 90 | examples/pdfjs-basicapi.pdf |
+| 3 | `serialize_after_rotate_to_zero` | rotation 90→0 후 re-parse → rotation == 0 (D4 추가) | examples/irs-f1040.pdf (rotation 있는 fixture) or 수동 구성 |
+| 4 | `serialize_after_delete` | DeletePagesCommand 후 re-parse → page count 감소 | examples/pdfjs-basicapi.pdf (3p→2p) |
+| 5 | `serialize_after_extract` | ExtractPagesCommand 후 re-parse → 추출 페이지 수 | examples/fw4-2024.pdf (5p) |
+| 6 | `serialize_after_split` | SplitCommand 후 각 Document serialize → 각 페이지 수 | examples/fw4-2024.pdf (5p) |
+| 7 | `serialize_after_merge` | MergeCommand 후 serialize → re-parse → 합산 페이지 수 | examples/irs-f1040.pdf (2p) + pdfjs-basicapi.pdf (3p) → 5p |
+| 8 | `serialize_empty_doc_error` | 빈 Document → EmptyDocument 에러 | — |
+| 9 | `serialize_source_length_mismatch_error` | sources.len() != pages.len() → SourceLengthMismatch 에러 | — |
+| 10 | `serialize_page_out_of_bounds_error` | source.page_index 초과 → PageOutOfBounds 에러 | — |
+
+---
+
+## 테스트 커버리지 다이어그램
+
+```
+CODE PATHS: serialize_document()
+  ├── [★★★ TEST #8] EmptyDocument error
+  ├── [★★★ TEST #9] SourceLengthMismatch error
+  ├── [SINGLE SOURCE]
+  │   ├── [★★★ TEST #1] basic roundtrip
+  │   ├── [★★★ TEST #10] PageOutOfBounds error
+  │   ├── [★★★ TEST #2] rotate 0→90
+  │   ├── [★★★ TEST #3] rotate 90→0 (D4 추가)
+  │   ├── [★★★ TEST #4] delete pages
+  │   ├── [★★★ TEST #5] extract pages
+  │   └── [★★★ TEST #6] split pages
+  └── [MULTI SOURCE]
+      └── [★★★ TEST #7] merge two sources
+
+COVERAGE: 10/10 paths (100%)
+QUALITY: ★★★:10
+GAPS: 0
+```
+
+---
+
+## 파일 변경 목록
+
+| 파일 | 변경 종류 |
+|------|---------|
+| ~~crates/rpdf-core/src/types/document.rs~~ | 변경 없음 (D1=B 결정) |
+| ~~crates/rpdf-parser/src/document.rs~~ | 변경 없음 (D1=B 결정) |
+| ~~crates/rpdf-edit/src/commands/mod.rs~~ | 변경 없음 |
+| `crates/rpdf-serializer/` | 신규 크레이트 (lib.rs, serialize.rs, types.rs, error.rs, tests/) |
+| `Cargo.toml` (workspace) | rpdf-serializer 멤버 추가, lopdf workspace dep 추가 |
+| `crates/rpdf-serializer/Cargo.toml` | 신규 |
+
+**참고**: rpdf-core·rpdf-parser·rpdf-edit 변경 없음.
+
+---
+
+## 체크포인트
+
+1. **CP-A**: rpdf-serializer 크레이트 스캐폴딩 — `cargo build` 통과
+2. **CP-B**: EmptyDocument/SourceLengthMismatch/PageOutOfBounds 에러 테스트 통과
+3. **CP-C**: 단일 소스 roundtrip (test #1, #8, #9, #10) 통과
+4. **CP-D**: rotate/delete/extract/split 테스트 (test #2, #3, #4, #5, #6) 통과
+5. **CP-E**: merge (다중 소스) 테스트 (test #7) 통과
+6. **CP-F**: 전체 `cargo test`, `cargo clippy`, `cargo fmt --check` 통과
+
+---
+
+## NOT in scope (이번 PR에서 다루지 않는 것)
+
+- 역순 페이지 재정렬 serialization
+- synthesized Page (source 없이 생성된 Page) 직렬화
+- incremental update 모드
+- 암호화 PDF 저장
+- Outlines/AcroForms 보존 merge (v0.4)
+- O(N²) split 성능 최적화 (v0.4)
+- rpdf-core 변경 (도메인 순수성 유지)
+
+---
+
+## What already exists
+
+- `samples/` 및 `examples/`에 28개 이상 PDF fixture — 신규 생성 불필요
+- `rpdf-parser::load_document` — 내부적으로 `load_document_tracked`가 래핑
+- `rpdf-edit::commands` 5개 — 변경 없이 그대로 사용
+- `rpdf-core::types::document::Document, Page` — 변경 없이 그대로 사용
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 6 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **UNRESOLVED:** 0 (모든 6개 결정 사항 해결됨)
+- **VERDICT:** ENG CLEARED — 구현 시작 가능.

--- a/mydocs/working/task22-done.md
+++ b/mydocs/working/task22-done.md
@@ -1,0 +1,105 @@
+# Task #22 완료 보고서: ExtractPagesCommand 구현
+
+**이슈**: #42  
+**브랜치**: `local/task22`  
+**완료일**: 2026-05-19
+
+---
+
+## 요약
+
+`rpdf-edit` 크레이트에 `ExtractPagesCommand`를 추가했다. `Query` 트레이트를 구현하며, 1-based 시작/끝 페이지 번호를 받아 원본 Document에서 해당 범위의 페이지를 추출한 새 `Document`를 반환한다. 원본 Document는 변경하지 않는다.
+
+추가로 4개 파일에 중복되어 있던 `make_doc` 테스트 헬퍼를 `mod.rs`의 공유 `test_utils` 모듈로 통합하는 DRY 리팩터링도 함께 진행했다.
+
+---
+
+## 구현 내용
+
+### 신규/수정 파일
+
+| 파일 | 변경 |
+|------|------|
+| `crates/rpdf-edit/src/commands/extract.rs` | 신규 생성 |
+| `crates/rpdf-edit/src/commands/mod.rs` | `extract` 모듈 추가, `test_utils` 공유 모듈 추가 |
+| `crates/rpdf-edit/src/commands/rotate.rs` | 로컬 `make_doc` 제거, `test_utils` 임포트 |
+| `crates/rpdf-edit/src/commands/delete.rs` | 동일 |
+| `crates/rpdf-edit/src/commands/merge.rs` | 동일 |
+| `crates/rpdf-edit/src/commands/split.rs` | 동일 |
+
+### 핵심 설계 결정
+
+- **`Query` 트레이트 구현**: 원본 불변이므로 Command 아님. `type Output = Document`.
+- **정수 인터페이스**: `new(start_page, end_page)` — 문자열 파싱 없이 명시적. SplitCommand와 인터페이스는 다르지만 1-based 정책은 일관.
+- **DRY 리팩터링 번들**: `make_doc`이 4개 파일에 이미 중복된 상태. 5번째 추가 전에 통합 결정.
+
+### 에러 처리
+
+| 조건 | 에러 메시지 | 발생 위치 |
+|------|------------|---------|
+| `start_page == 0` 또는 `end_page == 0` | "page numbers are 1-based, got 0" | `new()` |
+| `start_page > end_page` | "invalid range N-M: start > end" | `new()` |
+| 0-page Document | "document has no pages" | `execute()` |
+| 범위 초과 | "page index out of bounds: N" | `execute()` |
+
+---
+
+## 테스트 결과
+
+78개 단위 테스트 + 5개 doctest = 전체 통과.
+
+| # | 테스트명 | 결과 |
+|---|---------|------|
+| 1 | `extract_basic_range` | PASS |
+| 2 | `extract_single_page` | PASS |
+| 3 | `extract_entire_document` | PASS |
+| 4 | `extract_preserves_page_content` | PASS |
+| 5 | `extract_page_indices_reindexed` | PASS |
+| 6 | `extract_metadata_copied` | PASS |
+| 7 | `extract_out_of_bounds_end` | PASS |
+| 8 | `extract_start_out_of_bounds` | PASS |
+| 9 | `extract_zero_start_page` | PASS |
+| 10 | `extract_zero_end_page` | PASS |
+| 11 | `extract_start_greater_than_end` | PASS |
+| 12 | `extract_on_empty_document` | PASS |
+| 13 | `extract_original_doc_unchanged` | PASS |
+| 14 | `extract_last_page_boundary` | PASS |
+
+---
+
+## 품질 게이트
+
+| 게이트 | 결과 |
+|--------|------|
+| `cargo test --workspace --exclude rpdf-render` | PASS |
+| `cargo clippy --workspace --exclude rpdf-render -- -D warnings` | PASS (경고 0) |
+| `cargo fmt --all --check` | PASS |
+
+---
+
+## plan-eng-review 결과
+
+Outside Voice (Gemini) 6건 발견:
+
+| # | 발견 내용 | 판정 | 처리 |
+|---|---------|------|------|
+| 1 | Architectural Schizophrenia (string vs int API) | SCOPE-OUT | SplitCommand 이미 merge됨. 범위 외 |
+| 2 | Semantic Error Abuse (new()에서 ExecutionFailed 사용) | VALID/TODO | SplitCommand와 일관성 유지. 미래 리팩터링 후보 |
+| 3 | Redundant is_empty() check | FALSE POSITIVE | 명확한 에러 메시지 UX 목적 |
+| 4 | Memory/Performance (Page.clone) | VALID/TODO | 기존 SplitCommand와 동일 패턴 |
+| 5 | PDF Spec Violation (metadata ID) | FALSE POSITIVE | DocumentMetadata에 trailer ID 없음 |
+| 6 | Broken Internal References | VALID | NOT in scope에 명시 완료 |
+
+eng-review에서 추가 발견:
+- Code Quality: `make_doc` DRY 통합 → 이번 PR에서 처리
+- Test Gap: `extract_last_page_boundary` 누락 → 테스트 #14 추가
+
+---
+
+## 회고 분류
+
+| 항목 | 분류 | 내용 |
+|------|------|------|
+| make_doc 중복이 4개 파일에 이미 존재했지만 이전 task에서 방치됨 | B | `pub(crate) mod test_utils` 패턴: Rust에서 `#[cfg(test)]` 공유 헬퍼는 mod.rs에 test_utils 모듈로 두면 각 하위 모듈에서 `use super::test_utils::...`로 접근 가능 |
+| Outside Voice가 DocumentMetadata에 trailer ID 없음을 놓침 (false positive) | C | 도메인 모델 지식 없는 외부 AI는 구조체 내용을 모르는 상태에서 PDF 스펙 이슈를 추측할 수 있음 |
+| last-page boundary 테스트 plan-eng-review에서 발견 | A (긍정) | 리뷰 단계가 경계값 누락을 잡아냄 (13 → 14 테스트) |

--- a/mydocs/working/task23-done.md
+++ b/mydocs/working/task23-done.md
@@ -1,0 +1,128 @@
+# Task #23 완료 보고서: rpdf-serializer 구현
+
+**이슈**: #44  
+**브랜치**: `local/task23`  
+**완료일**: 2026-05-19
+
+---
+
+## 요약
+
+`rpdf-serializer` 크레이트를 신규 생성했다. lopdf 0.40.0을 직렬화 백엔드로 사용해 `Document` IR + `Vec<PageSource>`를 PDF 바이트(`Vec<u8>`)로 변환한다. 단일 소스(같은 원본 PDF에서 온 페이지들)와 다중 소스(여러 PDF를 합친 Document) 두 경로를 각각 구현했다.
+
+rpdf-core / rpdf-parser / rpdf-edit은 변경 없음. source tracking을 rpdf-serializer 내부 타입(`PageSource`)으로 분리해 도메인 레이어 오염을 방지했다.
+
+---
+
+## 구현 내용
+
+### 신규 파일
+
+| 파일 | 역할 |
+|------|------|
+| `crates/rpdf-serializer/Cargo.toml` | 신규 크레이트 설정 |
+| `crates/rpdf-serializer/src/lib.rs` | pub 재수출 |
+| `crates/rpdf-serializer/src/types.rs` | `PageSource { bytes: Arc<Vec<u8>>, page_index: usize }` |
+| `crates/rpdf-serializer/src/error.rs` | `SerializeError` 5개 변형 |
+| `crates/rpdf-serializer/src/serialize.rs` | `load_document_tracked` + `serialize_document` |
+| `crates/rpdf-serializer/tests/serialize_tests.rs` | 10개 통합 테스트 |
+
+### 수정 파일
+
+| 파일 | 변경 |
+|------|------|
+| `Cargo.toml` (루트) | `crates/rpdf-serializer` 멤버 추가, `lopdf = "0.40.0"` workspace dep 추가 |
+
+### 핵심 설계 결정
+
+- **source tracking 분리** (D1=B): `rpdf-core::Page`에 `source_bytes` 추가 불가. 도메인 레이어에 직렬화 관심사 오염. `PageSource`를 rpdf-serializer 내부 타입으로 분리.
+- **rotation 항상 쓰기** (D2=A): `rotation == 0`이어도 `/Rotate 0` 명시적 설정. 원본 /Rotate를 무조건 덮어씀. 조건 분기 없음. (90→0 복원 버그 방지)
+- **multi-source pseudo-code** (D3=A): renumber_objects_with → objects 병합 → Catalog/Pages 재구성 → /Parent 갱신 → rotation → save_to 전체 흐름 계획서에 명세.
+- **rotate-to-zero 테스트** (D4=A): 90→0 복원 경로 테스트 `serialize_after_rotate_to_zero` 추가.
+- **이중 파서 리스크** (D5=A): rpdf-parser 허용 PDF를 lopdf가 거부 가능 → `LoadSource` 에러 메시지에 "lopdf incompatible" 명시, 알려진 한계 문서화.
+- **Merge Outlines/AcroForms** (D6=A): renumber + Kids 재구성만으로는 북마크/폼 소실 → 알려진 한계 문서화, v0.4 이후 보완.
+
+### 에러 처리
+
+| 변형 | 조건 | 발생 위치 |
+|------|------|---------|
+| `EmptyDocument` | `doc.pages.is_empty()` | serialize.rs:56 |
+| `SourceLengthMismatch` | `sources.len() != doc.pages.len()` | serialize.rs:61 |
+| `LoadSource` | lopdf::load_mem 실패 | serialize.rs:88 (single), 164 (multi) |
+| `PageOutOfBounds` | `source.page_index >= lopdf_pages.len()` | serialize.rs:104 (single), 189 (multi) |
+| `Save` | save_to IO 에러 (`#[from]`) | serialize.rs:358 |
+
+### 알려진 한계
+
+- **이중 파서 불일치**: rpdf-parser가 허용한 PDF를 lopdf가 거부할 수 있음. `LoadSource` 에러로 표면화됨.
+- **Merge 시 Outlines/AcroForms 유실**: renumber + Kids 재구성만으로는 북마크·폼 데이터 소실. v0.4에서 보완 예정.
+- **O(N²) Split 성능**: 대량 split 시 load_mem 반복 호출. v0.3 범위에서 허용.
+
+---
+
+## 테스트 결과
+
+10개 통합 테스트 전체 통과.
+
+| # | 테스트명 | 결과 |
+|---|---------|------|
+| 1 | `serialize_basic_roundtrip` | PASS |
+| 2 | `serialize_after_rotate` (0→90) | PASS |
+| 3 | `serialize_after_rotate_to_zero` (90→0) | PASS |
+| 4 | `serialize_after_delete` | PASS |
+| 5 | `serialize_after_extract` | PASS |
+| 6 | `serialize_after_split` | PASS |
+| 7 | `serialize_after_merge` (다중 소스) | PASS |
+| 8 | `serialize_empty_doc_error` | PASS |
+| 9 | `serialize_source_length_mismatch_error` | PASS |
+| 10 | `serialize_page_out_of_bounds_error` | PASS |
+
+Fixtures: `examples/pdfjs-basicapi.pdf` (3p), `examples/irs-f1040.pdf` (2p), `examples/fw4-2024.pdf` (5p)
+
+---
+
+## 품질 게이트
+
+| 게이트 | 결과 |
+|--------|------|
+| `cargo test --workspace --exclude rpdf-render` | PASS |
+| `cargo clippy --workspace --exclude rpdf-render -- -D warnings` | PASS (경고 0) |
+| `cargo fmt --all --check` | PASS |
+
+---
+
+## evaluator 검증 결과
+
+4개 generator 요청 항목 모두 PASS.
+
+| # | 항목 | 결과 |
+|---|------|------|
+| 1 | serialize_multi_source Catalog/Pages 재구성 + /Parent 갱신 | PASS — lopdf 공식 merge 예제와 일치 |
+| 2 | renumber_objects_with 후 get_pages() 재호출 | PASS — renumber 후 BTreeMap 키 교체되므로 재계산 필수, 올바름 |
+| 3 | delete_pages 후 ObjectId 불변 가정 | PASS — lopdf가 objects.remove만 수행, 다른 OID 재배치 없음 |
+| 4 | SerializeError 5개 변형 dead variant 없음 | PASS — 전부 발생 경로 확인 |
+
+Enhancement (선택적): 다중 소스 경로에서 원본 소스 내 유지되지 않는 페이지들이 orphan 오브젝트로 남아 파일 크기 소폭 증가 가능. `prune_objects()` 호출로 제거 가능하나 v0.3 범위에서 허용 가능한 수준.
+
+---
+
+## plan-eng-review 결과
+
+outside voice (Gemini) 3건 발견:
+
+| # | 발견 내용 | 판정 | 처리 |
+|---|---------|------|------|
+| 1 | 이중 파서 불일치 리스크 | VALID | 알려진 한계 + LoadSource 에러메시지 개선 |
+| 2 | Merge 시 Outlines/AcroForms 유실 | VALID | 알려진 한계로 문서화, v0.4 이후 보완 |
+| 3 | O(N²) Split 성능 | VALID/TODO | v0.3 범위에서 허용, 알려진 한계 문서화 |
+
+---
+
+## 회고 분류
+
+| 항목 | 분류 | 내용 |
+|------|------|------|
+| rotation ≠ 0 조건 버그가 계획 초안에 있었음 | A (즉시 반영) | rotation 관련 로직은 "항상 쓰기" 패턴이 안전. 조건 분기는 버그를 숨김. CLAUDE.md "rotation 항상 쓰기" 교훈으로 추가 검토 필요 |
+| rpdf-core에 직렬화 관심사 오염 시도 | B | PageSource를 직렬화 크레이트 내부에 두는 패턴: 도메인 레이어(rpdf-core)에는 파싱·직렬화 관심사 없음. 새 크레이트 추가 시 rpdf-core 변경 유혹 주의 |
+| evaluator가 orphan 오브젝트 issue 발견 | C | 기능 동작에 영향 없는 파일 크기 소폭 증가. v0.3 허용 수준. prune_objects() 패턴 기억 |
+| gemini -C 플래그 미지원 오류 → approval-mode plan으로 수정 | B | gemini CLI 플래그: `--approval-mode plan -p "$PROMPT"` 패턴 사용. `-C` 디렉토리 플래그 미지원 |


### PR DESCRIPTION
## Summary

- `rpdf-serializer` 신규 크레이트 추가 — lopdf 0.40.0을 백엔드로 `Document` IR + `Vec<PageSource>`를 PDF 바이트로 직렬화
- 단일 소스 경로 (동일 원본 PDF): delete_pages + rotation 적용 + save_to
- 다중 소스 경로 (여러 PDF 합산): renumber_objects_with → objects 병합 → Catalog/Pages/Parent 재구성 → rotation → save_to
- source tracking(`PageSource`)을 rpdf-serializer 내부에 분리 — rpdf-core 도메인 레이어 오염 없음

## Test plan

- [x] `cargo test --package rpdf-serializer` — 10개 통합 테스트 전체 통과
  - serialize_basic_roundtrip
  - serialize_after_rotate (0→90)
  - serialize_after_rotate_to_zero (90→0, rotation=0 버그 방지)
  - serialize_after_delete
  - serialize_after_extract
  - serialize_after_split
  - serialize_after_merge (다중 소스)
  - serialize_empty_doc_error
  - serialize_source_length_mismatch_error
  - serialize_page_out_of_bounds_error
- [x] `cargo test --workspace --exclude rpdf-render` — 전체 통과
- [x] `cargo clippy --workspace --exclude rpdf-render -- -D warnings` — 경고 0
- [x] `cargo fmt --all --check` — 통과
- [x] evaluator 검증: Catalog/Pages 재구성·renumber·delete_pages ObjectId 불변·dead variant 없음 모두 PASS

## Known Limitations

- 이중 파서 불일치: rpdf-parser 허용 PDF를 lopdf가 거부 가능 (`LoadSource` 에러로 표면화)
- Merge 시 Outlines/AcroForms 유실 (v0.4에서 보완 예정)
- O(N²) Split 성능 (v0.3 범위 허용)

closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)