### PR TITLE
Task #25: rpdf-wasm crate — PdfDocument WASM 바인딩 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,34 @@ let idx = page - 1;
 > 열린 `<g transform>` 태그를 닫지 않아 `cm → q` 패턴 PDF에서 SVG 구조 파손.
 > → `SaveState` 진입 전에 `for _ in 0..loose_cm_depth { out.push_str("</g>\n"); }` 실행.
 
+커맨드 스택과 병렬로 관리하는 보조 스택(sources 등)이 있을 때, **보조 스택은 커맨드 스택과 항상 동일 높이**를 유지해야 한다.
+보조 상태를 변경하지 않는 커맨드도 반드시 sentinel을 push한다. 그렇지 않으면 커맨드를 혼합 실행한 뒤 undo 시 잘못된 스냅샷이 복원된다.
+
+```rust
+// 잘못된 패턴 — sources 변경 커맨드만 push → 혼합 시나리오에서 탈동기화
+fn execute_cmd(&mut self, cmd: Box<dyn Command>, new_sources: Option<Vec<PageSource>>) {
+    self.stack.execute(cmd, &mut self.doc)?;
+    if let Some(s) = new_sources {          // None이면 push 생략 → 높이 불일치
+        self.sources_undo.push(self.sources.clone());
+        self.sources = s;
+    }
+}
+
+// 올바른 패턴 — 항상 push → 커맨드 스택과 높이 일치 보장
+fn execute_cmd(&mut self, cmd: Box<dyn Command>, new_sources: Option<Vec<PageSource>>) {
+    self.stack.execute(cmd, &mut self.doc)?;
+    self.sources_undo.push(self.sources.clone()); // 항상 push
+    self.sources_redo.clear();
+    if let Some(s) = new_sources {
+        self.sources = s;
+    }
+}
+```
+
+> **사례**: `rpdf-wasm`의 `PdfDocument` — `rotate_page`는 sources 불변이라 `new_sources=None`으로만 처리했더니,
+> `rotate → delete → undo → undo` 시 sources_undo가 CommandStack보다 낮아 잘못된 스냅샷 복원.
+> → execute_cmd에서 `new_sources` 여부와 무관하게 항상 `sources_undo.push` 실행해 해결.
+
 ### PDF 속성 직렬화 — 항상 명시적 쓰기
 
 PDF 속성(rotation 등)을 직렬화할 때 "값이 기본값이면 생략" 조건 분기를 두지 않는다.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,11 +580,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1294,6 +1296,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpdf-wasm"
+version = "0.1.0"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "rpdf-core",
+ "rpdf-edit",
+ "rpdf-parser",
+ "rpdf-serializer",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1355,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = ["crates/rpdf-cli",
     "crates/rpdf-core", "crates/rpdf-edit", "crates/rpdf-parser", "crates/rpdf-render", "crates/rpdf-svg",
-    "crates/rpdf-serializer",
+    "crates/rpdf-serializer", "crates/rpdf-wasm",
 ]
 
 [workspace.package]
@@ -19,6 +19,9 @@ rpdf-parser = { path = "crates/rpdf-parser" }
 rpdf-render = { path = "crates/rpdf-render" }
 rpdf-serializer = { path = "crates/rpdf-serializer" }
 rpdf-svg = { path = "crates/rpdf-svg" }
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+js-sys = "0.3"
 lopdf = "0.40.0"
 thiserror = "2"
 anyhow = "1"

--- a/crates/rpdf-serializer/src/types.rs
+++ b/crates/rpdf-serializer/src/types.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 /// - `ExtractPagesCommand(1-5)`: `sources[0..=4]` — 범위 슬라이스
 /// - `SplitCommand`: 각 결과 doc의 page 원본 인덱스로 sources 슬라이스
 /// - `MergeCommand`: `a_sources + b_sources + ...` 순서로 연결
+#[derive(Clone)]
 pub struct PageSource {
     /// 원본 PDF 바이트. 동일한 파일에서 로드된 여러 PageSource는 같은 Arc를 공유한다.
     pub bytes: Arc<Vec<u8>>,

--- a/crates/rpdf-wasm/Cargo.toml
+++ b/crates/rpdf-wasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rpdf-wasm"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+rpdf-core.workspace = true
+rpdf-parser.workspace = true
+rpdf-edit.workspace = true
+rpdf-serializer.workspace = true
+wasm-bindgen = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+serde = { workspace = true }
+js-sys = { workspace = true }
+# getrandom의 wasm_js feature: wasm32-unknown-unknown 타겟에서 lopdf → rand → getrandom 의존성 때문에 필요
+getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/crates/rpdf-wasm/src/lib.rs
+++ b/crates/rpdf-wasm/src/lib.rs
@@ -509,7 +509,8 @@ mod tests {
         assert_eq!(pdf.sources.len(), pdf.page_count());
 
         // 2단계: delete_pages (sources 1 감소)
-        pdf.delete_pages(vec![1]).expect("delete_pages should succeed");
+        pdf.delete_pages(vec![1])
+            .expect("delete_pages should succeed");
         assert_eq!(pdf.page_count(), original_count - 1);
         assert_eq!(pdf.sources.len(), pdf.page_count());
 

--- a/crates/rpdf-wasm/src/lib.rs
+++ b/crates/rpdf-wasm/src/lib.rs
@@ -1,0 +1,526 @@
+use std::collections::HashSet;
+
+use js_sys::Error as JsError;
+use rpdf_core::types::document::Document;
+use rpdf_edit::commands::{CommandStack, DeletePagesCommand, RotatePageCommand};
+use rpdf_serializer::{PageSource, load_document_tracked, serialize_document};
+use wasm_bindgen::prelude::*;
+
+// ============================================================
+// 내부 헬퍼 — JsValue 없는 플레인 Rust (네이티브 단위 테스트 가능)
+// ============================================================
+
+/// 0-based 페이지 인덱스가 유효한지 검증한다.
+fn validate_page_index(idx: usize, count: usize) -> Result<(), String> {
+    if idx >= count {
+        return Err(format!("페이지 인덱스 범위 초과: {idx}"));
+    }
+    Ok(())
+}
+
+/// 회전각이 유효한지 검증한다. 0, 90, 180, 270만 허용한다.
+fn validate_degrees(degrees: i32) -> Result<(), String> {
+    match degrees {
+        0 | 90 | 180 | 270 => Ok(()),
+        _ => Err(format!(
+            "유효하지 않은 회전각: {degrees} (0/90/180/270만 허용)"
+        )),
+    }
+}
+
+/// 삭제 인덱스 목록이 유효한지 검증한다.
+///
+/// `page_count`는 현재 문서 페이지 수이다.
+fn validate_delete_indices(indices: &[usize], page_count: usize) -> Result<(), String> {
+    if indices.is_empty() {
+        return Err("삭제할 페이지 목록이 비어있습니다".to_string());
+    }
+    for &i in indices {
+        if i >= page_count {
+            return Err(format!("페이지 인덱스 범위 초과: {i}"));
+        }
+    }
+    Ok(())
+}
+
+/// 삭제 후 남은 sources를 반환한다.
+///
+/// `deleted_indices`는 0-based 인덱스 목록이다.
+fn compute_new_sources(sources: &[PageSource], deleted_indices: &[usize]) -> Vec<PageSource> {
+    let idx_set: HashSet<usize> = deleted_indices.iter().copied().collect();
+    sources
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !idx_set.contains(i))
+        .map(|(_, s)| PageSource {
+            bytes: s.bytes.clone(),
+            page_index: s.page_index,
+        })
+        .collect()
+}
+
+// ============================================================
+// 직렬화 구조체 — page_info 반환용
+// ============================================================
+
+#[derive(serde::Serialize)]
+struct PageInfo {
+    index: usize,
+    rotation: i32,
+    media_box: Option<[f64; 4]>,
+    crop_box: Option<[f64; 4]>,
+}
+
+// ============================================================
+// wasm_bindgen 구조체
+// ============================================================
+
+/// JS/TypeScript에서 PDF를 파싱·편집·저장하는 WASM API.
+#[wasm_bindgen]
+pub struct PdfDocument {
+    doc: Document,
+    sources: Vec<PageSource>,
+    stack: CommandStack,
+    sources_undo: Vec<Vec<PageSource>>,
+    sources_redo: Vec<Vec<PageSource>>,
+}
+
+#[wasm_bindgen]
+impl PdfDocument {
+    /// PDF 바이트에서 `PdfDocument`를 생성한다.
+    ///
+    /// # Errors
+    ///
+    /// 파싱 실패 시 JsValue 에러를 반환한다.
+    #[wasm_bindgen(constructor)]
+    pub fn new(data: &[u8]) -> Result<PdfDocument, JsValue> {
+        let (doc, sources) =
+            load_document_tracked(data).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        })
+    }
+
+    /// 문서의 페이지 수를 반환한다.
+    pub fn page_count(&self) -> usize {
+        self.doc.page_count()
+    }
+
+    /// 지정한 0-based 인덱스 페이지의 정보를 JsValue로 반환한다.
+    ///
+    /// 반환 형식: `{ index, rotation, media_box, crop_box }`
+    ///
+    /// # Errors
+    ///
+    /// - 인덱스가 범위를 초과하면 JsValue 에러를 반환한다.
+    pub fn page_info(&self, index: usize) -> Result<JsValue, JsValue> {
+        validate_page_index(index, self.doc.page_count())
+            .map_err(|e| JsValue::from(JsError::new(&e)))?;
+
+        let page = &self.doc.pages[index];
+        let info = PageInfo {
+            index: page.index,
+            rotation: page.rotation,
+            media_box: page.media_box,
+            crop_box: page.crop_box,
+        };
+        serde_wasm_bindgen::to_value(&info).map_err(|e| JsValue::from(JsError::new(&e.to_string())))
+    }
+
+    /// 현재 문서 상태를 PDF 바이트로 직렬화해 반환한다.
+    ///
+    /// # Errors
+    ///
+    /// 직렬화 실패 시 JsValue 에러를 반환한다.
+    pub fn save(&self) -> Result<Vec<u8>, JsValue> {
+        serialize_document(&self.doc, &self.sources)
+            .map_err(|e| JsValue::from(JsError::new(&e.to_string())))
+    }
+
+    /// 지정한 0-based 인덱스 페이지를 degrees만큼 회전한다.
+    ///
+    /// `degrees`는 0, 90, 180, 270만 허용한다.
+    ///
+    /// # Errors
+    ///
+    /// - 인덱스 범위 초과 또는 유효하지 않은 각도 시 JsValue 에러를 반환한다.
+    pub fn rotate_page(&mut self, index: usize, degrees: i32) -> Result<(), JsValue> {
+        validate_page_index(index, self.doc.page_count())
+            .map_err(|e| JsValue::from(JsError::new(&e)))?;
+        validate_degrees(degrees).map_err(|e| JsValue::from(JsError::new(&e)))?;
+
+        let cmd = Box::new(RotatePageCommand::new(index, degrees));
+        // rotate_page는 sources를 변경하지 않으므로 new_sources = None
+        self.execute_cmd(cmd, None)
+    }
+
+    /// 지정한 0-based 인덱스 목록에 해당하는 페이지를 삭제한다.
+    ///
+    /// `indices`는 JS `Uint32Array`와 대응하는 `Vec<u32>`이다.
+    ///
+    /// # Errors
+    ///
+    /// - 빈 목록, 인덱스 범위 초과 시 JsValue 에러를 반환한다.
+    pub fn delete_pages(&mut self, indices: Vec<u32>) -> Result<(), JsValue> {
+        let indices_usize: Vec<usize> = indices.iter().map(|&i| i as usize).collect();
+
+        validate_delete_indices(&indices_usize, self.doc.page_count())
+            .map_err(|e| JsValue::from(JsError::new(&e)))?;
+
+        let new_sources = compute_new_sources(&self.sources, &indices_usize);
+        let cmd = Box::new(DeletePagesCommand::new(indices_usize));
+        self.execute_cmd(cmd, Some(new_sources))
+    }
+
+    /// 마지막 편집을 되돌린다.
+    ///
+    /// # Errors
+    ///
+    /// 되돌릴 커맨드가 없으면 JsValue 에러를 반환한다.
+    pub fn undo(&mut self) -> Result<(), JsValue> {
+        if self.stack.undo_len() == 0 {
+            return Err(JsValue::from(JsError::new("되돌릴 커맨드 없음")));
+        }
+
+        self.stack
+            .undo(&mut self.doc)
+            .map_err(|e| JsValue::from(JsError::new(&e.to_string())))?;
+
+        // sources_undo는 CommandStack과 항상 동일 높이 — 반드시 pop 가능
+        let prev = self.sources_undo.pop().expect("sources_undo 높이 불일치");
+        let current = std::mem::replace(&mut self.sources, prev);
+        self.sources_redo.push(current);
+        Ok(())
+    }
+
+    /// 마지막으로 되돌린 편집을 다시 적용한다.
+    ///
+    /// # Errors
+    ///
+    /// 다시 실행할 커맨드가 없으면 JsValue 에러를 반환한다.
+    pub fn redo(&mut self) -> Result<(), JsValue> {
+        if self.stack.redo_len() == 0 {
+            return Err(JsValue::from(JsError::new("다시 실행할 커맨드 없음")));
+        }
+
+        self.stack
+            .redo(&mut self.doc)
+            .map_err(|e| JsValue::from(JsError::new(&e.to_string())))?;
+
+        // sources_redo는 CommandStack redo 스택과 항상 동일 높이 — 반드시 pop 가능
+        let next = self.sources_redo.pop().expect("sources_redo 높이 불일치");
+        let current = std::mem::replace(&mut self.sources, next);
+        self.sources_undo.push(current);
+        Ok(())
+    }
+
+    /// 현재 undo 스택 크기를 반환한다.
+    pub fn undo_len(&self) -> usize {
+        self.stack.undo_len()
+    }
+
+    /// 현재 redo 스택 크기를 반환한다.
+    pub fn redo_len(&self) -> usize {
+        self.stack.redo_len()
+    }
+}
+
+impl PdfDocument {
+    /// 커맨드를 실행하고 sources 스냅샷을 항상 push한다.
+    ///
+    /// execute 성공 후 현재 sources를 sources_undo에 항상 push해
+    /// CommandStack과 sources_undo의 높이를 일치시킨다.
+    /// `new_sources`가 Some이면 sources를 new_sources로 교체한다.
+    /// execute 실패 시에는 스냅샷을 push하지 않아 탈동기화를 방지한다.
+    fn execute_cmd(
+        &mut self,
+        cmd: Box<dyn rpdf_edit::commands::Command>,
+        new_sources: Option<Vec<PageSource>>,
+    ) -> Result<(), JsValue> {
+        // ⚠️ execute 성공 후에만 sources_undo push — 실패 시 스냅샷 탈동기화 방지
+        self.stack
+            .execute(cmd, &mut self.doc)
+            .map_err(|e| JsValue::from(JsError::new(&e.to_string())))?;
+
+        // 항상 push → CommandStack과 sources_undo 높이 일치 보장
+        self.sources_undo.push(self.sources.clone());
+        self.sources_redo.clear();
+        if let Some(s) = new_sources {
+            self.sources = s;
+        }
+        Ok(())
+    }
+}
+
+// ============================================================
+// 단위 테스트 — 네이티브 cargo test (JsValue 없는 내부 헬퍼 + PDF fixture)
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // PDF fixture: samples/trad-xref-basicapi.pdf (단순 1페이지 PDF)
+    const FIXTURE_BYTES: &[u8] = include_bytes!("../../../samples/trad-xref-basicapi.pdf");
+
+    // PDF fixture: samples/xref-stream-doc-13-pages.pdf (다중 페이지 PDF)
+    const MULTI_PAGE_FIXTURE: &[u8] =
+        include_bytes!("../../../samples/xref-stream-doc-13-pages.pdf");
+
+    // ── 내부 헬퍼 테스트 ──────────────────────────────────────
+
+    #[test]
+    fn validate_page_index_valid() {
+        assert!(validate_page_index(0, 5).is_ok());
+        assert!(validate_page_index(4, 5).is_ok());
+    }
+
+    #[test]
+    fn validate_page_index_out_of_bounds() {
+        let err = validate_page_index(5, 5).unwrap_err();
+        assert!(err.contains("페이지 인덱스 범위 초과: 5"));
+    }
+
+    #[test]
+    fn validate_degrees_valid() {
+        for d in [0, 90, 180, 270] {
+            assert!(validate_degrees(d).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_degrees_invalid() {
+        let err = validate_degrees(45).unwrap_err();
+        assert!(err.contains("유효하지 않은 회전각: 45"));
+    }
+
+    #[test]
+    fn compute_new_sources_removes_correct() {
+        let (_, sources) = load_document_tracked(MULTI_PAGE_FIXTURE).unwrap();
+        let original_len = sources.len();
+        let new_sources = compute_new_sources(&sources, &[0, 2]);
+        assert_eq!(new_sources.len(), original_len - 2);
+    }
+
+    // ── UT-01: new() — 유효한 PDF bytes → page_count > 0 ─────
+
+    #[test]
+    fn ut_01_new_valid_pdf() {
+        let (doc, _) = load_document_tracked(FIXTURE_BYTES).unwrap();
+        assert!(doc.page_count() > 0);
+    }
+
+    // ── UT-02: new() — 빈 bytes → Err ────────────────────────
+
+    #[test]
+    fn ut_02_new_empty_bytes() {
+        let result = load_document_tracked(&[]);
+        assert!(result.is_err());
+    }
+
+    // ── UT-03: rotate_page — 유효 인덱스·각도 → undo_len 1 증가
+
+    #[test]
+    fn ut_03_rotate_page_valid() {
+        let (doc, sources) = load_document_tracked(FIXTURE_BYTES).unwrap();
+        let mut pdf = PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        };
+        assert_eq!(pdf.undo_len(), 0);
+        pdf.rotate_page(0, 90).expect("rotate_page should succeed");
+        assert_eq!(pdf.undo_len(), 1);
+    }
+
+    // ── UT-04: rotate_page — 범위 초과 → Err ─────────────────
+    // 내부 헬퍼를 직접 테스트 (JsError::new는 비-wasm 타겟에서 호출 불가)
+
+    #[test]
+    fn ut_04_rotate_page_out_of_bounds() {
+        let (doc, _) = load_document_tracked(FIXTURE_BYTES).unwrap();
+        // validate_page_index가 에러를 반환함을 검증
+        let result = validate_page_index(9999, doc.page_count());
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("페이지 인덱스 범위 초과: 9999"));
+    }
+
+    // ── UT-05: rotate_page — 유효하지 않은 각도 → Err ────────
+    // 내부 헬퍼를 직접 테스트 (JsError::new는 비-wasm 타겟에서 호출 불가)
+
+    #[test]
+    fn ut_05_rotate_page_invalid_degrees() {
+        let result = validate_degrees(45);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("유효하지 않은 회전각: 45"));
+    }
+
+    // ── UT-06: delete_pages — 유효 인덱스 → page_count 감소 ──
+
+    #[test]
+    fn ut_06_delete_pages_valid() {
+        let (doc, sources) = load_document_tracked(MULTI_PAGE_FIXTURE).unwrap();
+        let original_count = doc.page_count();
+        let mut pdf = PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        };
+        pdf.delete_pages(vec![0])
+            .expect("delete_pages should succeed");
+        assert_eq!(pdf.page_count(), original_count - 1);
+    }
+
+    // ── UT-07: delete_pages — 빈 목록 → Err ──────────────────
+
+    #[test]
+    fn ut_07_delete_pages_empty() {
+        let result = validate_delete_indices(&[], 5);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("비어있습니다"));
+    }
+
+    // ── UT-08: undo → undo_len 감소, redo_len 증가, sources.len() == page_count()
+
+    #[test]
+    fn ut_08_undo_sources_consistency() {
+        let (doc, sources) = load_document_tracked(MULTI_PAGE_FIXTURE).unwrap();
+        let mut pdf = PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        };
+        pdf.delete_pages(vec![0]).unwrap();
+        let undo_len_before = pdf.undo_len();
+        pdf.undo().unwrap();
+        assert_eq!(pdf.undo_len(), undo_len_before - 1);
+        assert_eq!(pdf.redo_len(), 1);
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+    }
+
+    // ── UT-09: redo → redo_len 감소, undo_len 증가, sources.len() == page_count()
+
+    #[test]
+    fn ut_09_redo_sources_consistency() {
+        let (doc, sources) = load_document_tracked(MULTI_PAGE_FIXTURE).unwrap();
+        let mut pdf = PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        };
+        pdf.delete_pages(vec![0]).unwrap();
+        pdf.undo().unwrap();
+        pdf.redo().unwrap();
+        assert_eq!(pdf.redo_len(), 0);
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+    }
+
+    // ── UT-10: save — 유효 문서 → bytes 비어있지 않음 ─────────
+
+    #[test]
+    fn ut_10_save_non_empty() {
+        let (doc, sources) = load_document_tracked(FIXTURE_BYTES).unwrap();
+        let pdf = PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        };
+        let bytes = pdf.save().expect("save should succeed");
+        assert!(!bytes.is_empty());
+    }
+
+    // ── UT-11: delete_pages → undo → save → 성공 (sources 복원 검증) ─
+
+    #[test]
+    fn ut_11_delete_undo_save() {
+        let (doc, sources) = load_document_tracked(MULTI_PAGE_FIXTURE).unwrap();
+        let original_count = doc.page_count();
+        let mut pdf = PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        };
+        pdf.delete_pages(vec![0]).unwrap();
+        assert_eq!(pdf.page_count(), original_count - 1);
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+
+        pdf.undo().unwrap();
+        assert_eq!(pdf.page_count(), original_count);
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+
+        let bytes = pdf.save().expect("save after undo should succeed");
+        assert!(!bytes.is_empty());
+    }
+
+    // ── UT-12: page_info — rotation/media_box 필드 포함 ───────
+
+    #[test]
+    fn ut_12_page_info_fields() {
+        let (doc, _sources) = load_document_tracked(FIXTURE_BYTES).unwrap();
+        // page_info는 내부 헬퍼로 직접 테스트
+        let page = &doc.pages[0];
+        let info = PageInfo {
+            index: page.index,
+            rotation: page.rotation,
+            media_box: page.media_box,
+            crop_box: page.crop_box,
+        };
+        // rotation 필드가 유효한 값인지 확인
+        assert!(matches!(info.rotation, 0 | 90 | 180 | 270));
+        // index 필드 확인
+        assert_eq!(info.index, 0);
+    }
+
+    // ── UT-13: 혼합 커맨드 — rotate_page → delete_pages → undo → undo
+    //          sources.len() == doc.page_count() 일관성 검증
+
+    #[test]
+    fn ut_13_mixed_commands_undo_consistency() {
+        let (doc, sources) = load_document_tracked(MULTI_PAGE_FIXTURE).unwrap();
+        let original_count = doc.page_count();
+        let mut pdf = PdfDocument {
+            doc,
+            sources,
+            stack: CommandStack::new(50),
+            sources_undo: Vec::new(),
+            sources_redo: Vec::new(),
+        };
+
+        // 1단계: rotate_page (sources 변경 없음)
+        pdf.rotate_page(0, 90).expect("rotate_page should succeed");
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+
+        // 2단계: delete_pages (sources 1 감소)
+        pdf.delete_pages(vec![1]).expect("delete_pages should succeed");
+        assert_eq!(pdf.page_count(), original_count - 1);
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+
+        // 3단계: undo delete_pages → sources 복원
+        pdf.undo().expect("undo delete should succeed");
+        assert_eq!(pdf.page_count(), original_count);
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+
+        // 4단계: undo rotate_page → sources 여전히 일치
+        pdf.undo().expect("undo rotate should succeed");
+        assert_eq!(pdf.page_count(), original_count);
+        assert_eq!(pdf.sources.len(), pdf.page_count());
+    }
+}

--- a/mydocs/plans/task25-wasm-api.md
+++ b/mydocs/plans/task25-wasm-api.md
@@ -1,0 +1,478 @@
+# Task #25 계획서 — wasm_api 모듈 작성
+
+**Issue**: #48  
+**브랜치**: `local/task25`  
+**마일스톤**: M040 (v0.4 WASM 바인딩)  
+**선행 조건**: v0.3 완료 ✅ (Task #21~#24)
+
+---
+
+## 목표
+
+Rust 코어를 WebAssembly로 컴파일하기 위한 `rpdf-wasm` crate를 신규 생성한다.  
+`PdfDocument` wasm_bindgen 구조체를 통해 JS/TypeScript에서 PDF 파싱·편집·저장 API를 제공한다.  
+렌더링은 JS 측 pdf.js에 위임한다 (`pdfium-render`는 WASM 미지원).
+
+---
+
+## 버전 정보 (실제 설치 기준)
+
+| 도구 | 버전 |
+|------|------|
+| Rust | 1.87.0 |
+| wasm-pack | 미설치 → 이번 Task에서 설치 |
+| wasm-bindgen | 0.2 (최신 호환) |
+| wasm32-unknown-unknown target | rust target 추가 필요 확인 |
+
+---
+
+## 공개 API 확인 완료
+
+### wasm-bindgen 0.2
+- `#[wasm_bindgen]` — 구조체·함수 노출 매크로
+- `JsValue` — JS 오류 전달 타입
+- `#[wasm_bindgen(js_name = "...")]` — JS 측 이름 커스텀
+- `wasm_bindgen::throw_str(...)` — JS에 에러 전달
+- `js_sys::Uint8Array` — JS Uint8Array ↔ Rust Vec<u8>
+
+### 현재 Rust 코어 공개 API
+- `rpdf_parser::load_document_tracked(data: &[u8]) → Result<(Document, Vec<PageSource>), ParseError>`
+  - 불가. `load_document_tracked`는 `rpdf-serializer`에 있음
+- `rpdf_serializer::load_document_tracked(data: &[u8]) → Result<(Document, Vec<PageSource>), ParseError>`
+- `rpdf_serializer::serialize_document(doc: &Document, sources: &[PageSource]) → Result<Vec<u8>, SerializeError>`
+- `rpdf_edit::commands::RotatePageCommand`, `DeletePagesCommand`, `MergeCommand`, `SplitCommand`, `ExtractPagesCommand`
+- `rpdf_edit::commands::CommandStack::new(max_depth: usize) → CommandStack`
+- `CommandStack::execute(cmd, doc)`, `::undo(doc)`, `::redo(doc)`
+
+---
+
+## 데이터 모델
+
+### `PdfDocument` (wasm_bindgen 구조체)
+
+```rust
+#[wasm_bindgen]
+pub struct PdfDocument {
+    doc: Document,
+    sources: Vec<PageSource>,
+    stack: CommandStack,
+    // undo/redo 시 sources 동기화를 위한 스냅샷 스택
+    sources_undo: Vec<Vec<PageSource>>,
+    sources_redo: Vec<Vec<PageSource>>,
+}
+```
+
+**설계 근거**:
+- WASM은 단일 스레드 → `Send + Sync` 불필요
+- `CommandStack`의 `Box<dyn Command: Send + Sync>`는 WASM에서 trivially 충족
+- `sources`는 `rpdf-serializer`의 `PageSource` — `serialize_document` 호출 시 필요
+- **sources 스냅샷 필수**: `delete_pages` 후 `undo()` 시 `doc.pages`는 복원되지만 `sources`는 자동 복원 안 됨. `sources_undo`/`sources_redo` 스택으로 동기화.
+  - `PageSource`는 `Arc<Vec<u8>>`를 포함하므로 clone 비용이 낮음 (bytes 공유, 포인터만 복제)
+
+### `execute_cmd` 내부 헬퍼
+
+`rotate_page`, `delete_pages` 등 커맨드 실행 공통 흐름을 헬퍼로 추출:
+
+```rust
+fn execute_cmd(&mut self, cmd: Box<dyn Command>, new_sources: Option<Vec<PageSource>>) -> Result<(), JsValue> {
+    // ⚠️ sources_undo push는 반드시 execute 성공 후에 수행
+    // execute 실패 시 스냅샷을 push하면 스택 탈동기화 발생 (Gemini 지적)
+    self.stack.execute(cmd, &mut self.doc).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    // execute 성공 → 현재 sources를 undo 스택에 push, redo 스택 클리어
+    // rotate_page 는 new_sources=None (sources 변경 없음, 스냅샷도 push 불필요)
+    if let Some(s) = new_sources {
+        self.sources_undo.push(self.sources.clone());
+        self.sources_redo.clear();
+        self.sources = s;
+    }
+    Ok(())
+}
+```
+
+**중요**: `rotate_page`는 sources를 변경하지 않으므로 `new_sources = None` 전달. `sources_undo` push 생략으로 불필요한 메모리 낭비 방지.
+
+### WasmError
+
+wasm_bindgen 구조체의 `Result<T, JsValue>` 패턴을 사용한다.  
+에러 변환 시 `js_sys::Error::new(&e.to_string()).into()`를 사용한다.
+
+> **근거**: `JsValue::from_str()`는 JS 문자열 원시값만 반환하여 스택 트레이스가 없고 `instanceof Error` 체크도 실패함. `js_sys::Error::new()`는 JS `Error` 객체를 생성해 표준 에러 처리 패턴을 지원 (Gemini 지적).
+
+### 내부 로직 분리 전략
+
+네이티브 `cargo test`에서 `JsValue`/`js_sys` 타입 없이 로직을 테스트하기 위해:
+
+```rust
+// 내부 헬퍼 (JsValue 없는 플레인 Rust — 네이티브 단위 테스트 가능)
+fn validate_page_index(idx: usize, count: usize) -> Result<(), String> { ... }
+fn compute_new_sources(sources: &[PageSource], deleted: &[usize]) -> Vec<PageSource> { ... }
+fn validate_degrees(degrees: i32) -> Result<(), String> { ... }
+
+// wasm 바인딩 레이어 (보일러플레이트만, 로직 없음)
+#[wasm_bindgen]
+pub fn rotate_page(&mut self, index: usize, degrees: i32) -> Result<(), JsValue> {
+    validate_page_index(index, self.doc.page_count())
+        .map_err(|e| js_sys::Error::new(&e).into())?;
+    validate_degrees(degrees).map_err(|e| js_sys::Error::new(&e).into())?;
+    ...
+}
+```
+
+`#[cfg(test)]` 블록은 내부 헬퍼만 테스트. wasm 바인딩 레이어는 `wasm-pack test --node`로 별도 검증.
+
+---
+
+## 공개 API 명세
+
+### `PdfDocument::new(data: &[u8]) → Result<PdfDocument, JsValue>`
+
+```rust
+#[wasm_bindgen(constructor)]
+pub fn new(data: &[u8]) -> Result<PdfDocument, JsValue>
+```
+
+- `load_document_tracked(data)` 호출
+- 성공 시 `CommandStack::new(50)` 생성 (undo 50단계)
+- 실패 시 `js_sys::Error::new(&e.to_string()).into()`
+
+### `page_count() → usize`
+
+```rust
+pub fn page_count(&self) -> usize
+```
+
+- `self.doc.page_count()` 반환
+
+### `page_info(index: usize) → JsValue`
+
+```rust
+pub fn page_info(&self, index: usize) -> Result<JsValue, JsValue>
+```
+
+- `index < page_count()` 검증
+- JSON 직렬화: `{ index, rotation, media_box, crop_box }`
+- `serde-wasm-bindgen`으로 Rust struct → JsValue 변환
+- 실패 시 JsValue 에러
+
+### `rotate_page(index: usize, degrees: i32) → Result<(), JsValue>`
+
+```rust
+pub fn rotate_page(&mut self, index: usize, degrees: i32) -> Result<(), JsValue>
+```
+
+- `index` 범위 검증 (`index >= page_count()` → 에러)
+- `degrees` 유효값 검증 (`0, 90, 180, 270` 외 → 에러)
+- `RotatePageCommand::new(index, degrees)` — **0-based index** (CLI 핸들러 확인)
+- `self.stack.execute(Box::new(cmd), &mut self.doc)`
+
+### `delete_pages(indices: Vec<u32>) → Result<(), JsValue>`
+
+```rust
+pub fn delete_pages(&mut self, indices: Vec<u32>) -> Result<(), JsValue>
+```
+
+- `indices` 비어있으면 에러
+- `indices`의 각 항목이 `0-based` 유효 범위인지 검증 (내부 헬퍼 `validate_page_index` 사용)
+- `usize` 변환 후 `DeletePagesCommand::new(indices_usize)` — **0-based indices** (CLI 핸들러 확인)
+- `execute_cmd(cmd, Some(new_sources))` 호출
+- **new_sources 계산 (execute_cmd 호출 전)**:
+  ```rust
+  let idx_set: HashSet<usize> = indices_usize.iter().copied().collect();
+  let new_sources: Vec<PageSource> = self.sources.iter()
+      .enumerate()
+      .filter(|(i, _)| !idx_set.contains(i))
+      .map(|(_, s)| s.clone())
+      .collect();
+  ```
+
+> **타입 근거**: `Vec<u32>` 사용 시 JS `Uint32Array`와 명확히 매핑됨. `Vec<usize>`는 플랫폼에 따라 32/64비트 불일치 가능 (Gemini 지적).
+
+### `save() → Result<Vec<u8>, JsValue>`
+
+```rust
+pub fn save(&self) -> Result<Vec<u8>, JsValue>
+```
+
+- `serialize_document(&self.doc, &self.sources)` 호출
+- 성공 시 `Vec<u8>` 반환
+- 실패 시 JsValue 에러
+
+### `undo() → Result<(), JsValue>`
+
+```rust
+pub fn undo(&mut self) -> Result<(), JsValue>
+```
+
+- `sources_undo` 비어있으면 에러
+- `self.stack.undo(&mut self.doc)` 호출
+- 성공 시: `sources_redo.push(self.sources.clone())`, `self.sources = sources_undo.pop()`
+- `CommandError::NothingToUndo` → JsValue 에러 ("되돌릴 커맨드 없음")
+
+### `redo() → Result<(), JsValue>`
+
+```rust
+pub fn redo(&mut self) -> Result<(), JsValue>
+```
+
+- `sources_redo` 비어있으면 에러
+- `self.stack.redo(&mut self.doc)` 호출
+- 성공 시: `sources_undo.push(self.sources.clone())`, `self.sources = sources_redo.pop()`
+- `CommandError::NothingToRedo` → JsValue 에러 ("다시 실행할 커맨드 없음")
+
+### `undo_len() → usize` / `redo_len() → usize`
+
+```rust
+pub fn undo_len(&self) -> usize
+pub fn redo_len(&self) -> usize
+```
+
+---
+
+## 에러 처리 표
+
+| 상황 | 에러 | 발생 위치 |
+|------|------|-----------|
+| PDF 파싱 실패 | `ParseError::...` → JsValue | `new()` |
+| `rotate_page` index 범위 초과 | `"페이지 인덱스 범위 초과: {index}"` → JsValue | `rotate_page()` |
+| `rotate_page` 유효하지 않은 degrees | `"유효하지 않은 회전각: {degrees} (0/90/180/270만 허용)"` → JsValue | `rotate_page()` |
+| `delete_pages` 빈 목록 | `"삭제할 페이지 목록이 비어있습니다"` → JsValue | `delete_pages()` |
+| `delete_pages` index 범위 초과 | `"페이지 인덱스 범위 초과: {i}"` → JsValue | `delete_pages()` |
+| serialize 실패 | `SerializeError::...` → JsValue | `save()` |
+| undo 없음 | `"되돌릴 커맨드 없음"` → JsValue | `undo()` |
+| redo 없음 | `"다시 실행할 커맨드 없음"` → JsValue | `redo()` |
+| `page_info` index 범위 초과 | `"페이지 인덱스 범위 초과: {index}"` → JsValue | `page_info()` |
+
+---
+
+## 하위 커맨드 인덱스 정책 (CLI 핸들러 확인 완료)
+
+- `RotatePageCommand::new(page_index, degrees)` — **0-based** index
+  - CLI는 1-based 입력을 `page - 1`로 변환 후 호출
+- `DeletePagesCommand::new(indices)` — **0-based** indices
+  - CLI의 `parse_page_list`가 0-based 변환 처리
+- wasm API는 **0-based index를 JS 측에서 받아 그대로 Command에 전달**
+- `delete_pages` 실행 후 `self.sources`를 수동으로 동기화해야 함 (CLI 핸들러 패턴 동일)
+
+---
+
+## 파일 구조
+
+```
+crates/rpdf-wasm/
+├── Cargo.toml
+└── src/
+    └── lib.rs          — PdfDocument wasm_bindgen 구현
+```
+
+---
+
+## Cargo.toml 설계
+
+```toml
+[package]
+name = "rpdf-wasm"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+rpdf-core.workspace = true
+rpdf-parser.workspace = true
+rpdf-edit.workspace = true
+rpdf-serializer.workspace = true
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+serde.workspace = true
+js-sys = "0.3"
+```
+
+> **주의**: `rpdf-render`는 pdfium 네이티브 의존이므로 WASM crate에서 제외.
+
+### workspace Cargo.toml 추가
+
+```toml
+# [workspace.dependencies] 추가
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+js-sys = "0.3"
+
+# [workspace] members 추가
+"crates/rpdf-wasm",
+```
+
+---
+
+## 체크포인트
+
+### CP-A: 환경 준비 + crate 생성 + 빌드 통과
+
+**작업 범위**:
+1. wasm-pack 설치 (`cargo install wasm-pack`)
+2. wasm32 target 추가 (`rustup target add wasm32-unknown-unknown`)
+3. `cargo new --lib crates/rpdf-wasm --vcs none`
+4. workspace Cargo.toml — members + dependencies 추가
+5. `rpdf-wasm/Cargo.toml` 작성 (cdylib + rlib, wasm-bindgen 의존)
+6. `src/lib.rs` — 빈 `PdfDocument` 구조체 + `#[wasm_bindgen]` 스캐폴딩
+7. `wasm-pack build --target web --dev` 빌드 성공
+
+**통과 기준**: `wasm-pack build` 성공, `pkg/` 디렉터리 생성
+
+---
+
+### CP-B: 핵심 API 구현 (new / page_count / save / page_info)
+
+**작업 범위**:
+1. `PdfDocument::new(data: &[u8])` — `load_document_tracked` 호출
+2. `page_count()` — `self.doc.page_count()` 반환
+3. `page_info(index)` — JSON 직렬화 반환
+4. `save()` — `serialize_document` 호출
+
+**테스트 (wasm-pack test용 아닌 단위 테스트, `rlib` 대상)**:
+- `rpdf-wasm` crate의 `src/lib.rs` 내 `#[cfg(test)]` 블록
+- 단, WASM 컨텍스트가 아닌 네이티브에서 단위 테스트 가능한 로직 분리
+
+**통과 기준**: `cargo test -p rpdf-wasm` 성공
+
+---
+
+### CP-C: 편집 API 구현 (rotate_page / delete_pages / undo / redo)
+
+**작업 범위**:
+1. `rotate_page(index, degrees)` — 범위·각도 검증 + RotatePageCommand
+2. `delete_pages(indices)` — 빈 목록·범위 검증 + DeletePagesCommand
+3. `undo()` / `redo()` — CommandStack 위임
+4. `undo_len()` / `redo_len()`
+
+**에러 처리**: 모든 에러 → `JsValue::from_str()`
+
+**통과 기준**: `cargo test -p rpdf-wasm` 성공, clippy 경고 없음
+
+---
+
+### CP-D: wasm-pack 빌드 검증 + 번들 크기
+
+**작업 범위**:
+1. `wasm-pack build --target web` (release 빌드)
+2. `wasm-opt` 적용 확인 (wasm-pack이 자동 적용)
+3. `pkg/rpdf_wasm_bg.wasm` gzip 크기 측정 → 2MB 이하 확인
+4. `cargo clippy -p rpdf-wasm --target wasm32-unknown-unknown -- -D warnings`
+
+**통과 기준**: 번들 크기 2MB 이하 (gzip), clippy 경고 없음
+
+---
+
+## 엣지 케이스
+
+| 케이스 | 처리 |
+|--------|------|
+| `new()` — 빈 슬라이스 | ParseError 반환 |
+| `rotate_page(0, 90)` — 유효한 인덱스 | 정상 처리 |
+| `rotate_page(999, 90)` — 범위 초과 | 에러 반환 |
+| `rotate_page(0, 45)` — 유효하지 않은 각도 | 에러 반환 |
+| `delete_pages([])` — 빈 목록 | 에러 반환 |
+| `delete_pages` 전체 페이지 삭제 | DeletePagesCommand 에러 전파 |
+| `undo()` — 스택 비어있음 | 에러 반환 |
+| `save()` — delete 후 빈 문서 | SerializeError::EmptyDocument 전파 |
+
+---
+
+## 테스트 전략
+
+WASM 환경 테스트는 `wasm-pack test --headless --chrome`이 필요하지만,
+`wasm-bindgen`을 사용하지 않는 내부 로직은 네이티브 단위 테스트로 검증한다.
+
+### 네이티브 단위 테스트 (`cargo test -p rpdf-wasm`)
+
+```
+UT-01: new() — 유효한 PDF bytes → page_count > 0
+UT-02: new() — 빈 bytes → Err
+UT-03: rotate_page — 유효 인덱스·각도 → undo_len 1 증가
+UT-04: rotate_page — 범위 초과 → Err
+UT-05: rotate_page — 유효하지 않은 각도 → Err
+UT-06: delete_pages — 유효 인덱스 → page_count 감소
+UT-07: delete_pages — 빈 목록 → Err
+UT-08: undo → undo_len 감소, redo_len 증가, sources.len() == page_count()
+UT-09: redo → redo_len 감소, undo_len 증가, sources.len() == page_count()
+UT-10: save — 유효 문서 → bytes 비어있지 않음
+UT-11: delete_pages → undo → save → 성공 (sources.len() 복원 검증)
+UT-12: page_info — 유효 인덱스 → rotation/media_box 필드 포함
+```
+
+**테스트용 PDF fixture**: `crates/rpdf-parser/tests/fixtures/` 기존 파일 재사용
+
+---
+
+## 위험 요소
+
+| 위험 | 대응 |
+|------|------|
+| `RotatePageCommand` 시그니처가 1-based인지 0-based인지 불명확 | 구현 전 CLI 핸들러 코드 확인 필수 |
+| `sources`와 `doc.pages` 동기화 (편집 후) | `RotatePageCommand`·`DeletePagesCommand`의 sources 처리 방식 확인 |
+| WASM target에서 `Box<dyn Command: Send + Sync>` 컴파일 | WASM은 단일 스레드이므로 trivially 충족 — 문제 없음 예상 |
+| wasm-bindgen 버전 ↔ wasm-pack 버전 불일치 | wasm-pack 설치 후 호환 버전 확인 |
+
+---
+
+## 완료 기준
+
+1. `rpdf-wasm` crate 신규 생성, `wasm-pack build --target web` 성공
+2. `PdfDocument` 공개 API — `new`, `page_count`, `page_info`, `rotate_page`, `delete_pages`, `save`, `undo`, `redo`, `undo_len`, `redo_len`
+3. 네이티브 단위 테스트 UT-01~UT-12 모두 통과 (내부 헬퍼 분리 기반)
+4. `cargo clippy -p rpdf-wasm -- -D warnings` 경고 없음
+5. WASM 번들 크기 2MB 이하 (gzip)
+
+---
+
+## 범위 외
+
+- npm 패키지 구성 (Task #28)
+- rpdf-studio 웹 에디터 (Task #29)
+- GitHub Pages 배포 (Task #30)
+- PDFium WASM 대체 전략 상세 구현 (Task #26)
+
+---
+
+closes #48
+
+---
+
+## Implementation Tasks
+
+Synthesized from this review's findings. Each task derives from a specific finding above.
+
+- [ ] **T1 (P1, human: ~30min / CC: ~5min)** — rpdf-wasm/src/lib.rs — execute_cmd: sources_undo push를 execute() 성공 후로 이동
+  - Surfaced by: Architecture Review — execute 실패 시 스냅샷 탈동기화
+  - Files: `crates/rpdf-wasm/src/lib.rs`
+  - Verify: UT-11 (delete→undo→save) 통과
+
+- [ ] **T2 (P1, human: ~1h / CC: ~10min)** — rpdf-wasm/src/lib.rs — 내부 로직을 JsValue-free 헬퍼로 분리해 native cargo test 가능하게 함
+  - Surfaced by: Test Review — JsValue 타입으로 네이티브 컴파일 실패 (Gemini 지적)
+  - Files: `crates/rpdf-wasm/src/lib.rs`
+  - Verify: `cargo test -p rpdf-wasm` 성공
+
+- [ ] **T3 (P2, human: ~15min / CC: ~3min)** — rpdf-wasm/src/lib.rs — JsValue::from_str → js_sys::Error::new().into() 교체
+  - Surfaced by: Code Quality — JS Error 타입 표준 준수 (Gemini 지적)
+  - Files: `crates/rpdf-wasm/src/lib.rs`
+  - Verify: 모든 에러 반환이 `js_sys::Error` 객체
+
+- [ ] **T4 (P2, human: ~30min / CC: ~5min)** — rpdf-wasm/src/lib.rs — UT-11 (delete→undo→save) / UT-12 (page_info) 추가
+  - Surfaced by: Test Review — sources 복원 경로 미검증
+  - Files: `crates/rpdf-wasm/src/lib.rs`
+  - Verify: `cargo test -p rpdf-wasm` 12개 테스트 통과
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 4 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **UNRESOLVED:** 0
+- **VERDICT:** ENG CLEARED — ready to implement

--- a/mydocs/troubleshootings/wasm-bindgen-native-test-jserror.md
+++ b/mydocs/troubleshootings/wasm-bindgen-native-test-jserror.md
@@ -1,0 +1,165 @@
+# 트러블슈팅 — wasm-bindgen JsError를 포함한 메서드의 네이티브 cargo test 실패
+
+**발생일**: 2026-05-19  
+**해결일**: 2026-05-19  
+**관련 Issue**: #48 (Task #25)  
+**심각도**: 중간  
+**환경**: Rust 1.87.0 / wasm-bindgen 0.2 / wasm32-unknown-unknown
+
+---
+
+## 증상
+
+`#[wasm_bindgen]` impl 블록 안에서 `js_sys::Error::new(...)` 또는 `JsError::new(...)`를 에러 변환에 사용하는 메서드를, 네이티브 타겟(`x86_64-apple-darwin` 등)에서 `cargo test -p rpdf-wasm`로 호출하면 컴파일은 통과하지만 런타임에 패닉 발생.
+
+```
+# cargo test -p rpdf-wasm
+test ut_07_delete_pages_empty ... FAILED
+
+thread 'ut_07_delete_pages_empty' panicked at 'not implemented',
+wasm-bindgen/src/lib.rs:XXX:XX
+```
+
+또는 메서드 자체를 인라인으로 네이티브 테스트에서 호출할 수 없어 컴파일 에러 발생:
+```
+error[E0433]: failed to resolve: use of undeclared crate or module `js_sys`
+```
+
+---
+
+## 재현 방법
+
+```rust
+#[wasm_bindgen]
+pub fn delete_pages(&mut self, indices: Vec<u32>) -> Result<(), JsValue> {
+    if indices.is_empty() {
+        return Err(JsValue::from(JsError::new("삭제할 페이지 목록이 비어있습니다")));
+    }
+    // ...
+}
+
+// 테스트에서 직접 호출 시도
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_delete_empty() {
+        let mut pdf = make_pdf_document();
+        let result = pdf.delete_pages(vec![]);  // 네이티브에서 호출 → 런타임 패닉
+        assert!(result.is_err());
+    }
+}
+```
+
+```bash
+cargo test -p rpdf-wasm
+# → 패닉 또는 컴파일 에러
+```
+
+---
+
+## 원인 분석
+
+### 최종 원인
+
+`js_sys::Error`·`JsError` 등 wasm-bindgen JS 런타임 타입은 **wasm32 타겟에서만 유효**한 타입이다. 네이티브 타겟에서 컴파일은 조건부로 가능하지만, 런타임에 실제 JS 엔진이 없으므로 패닉을 일으킨다.
+
+`wasm-bindgen`의 많은 JS 타입이 네이티브에서 `unimplemented!()` 매크로로 구현되어 있어 `cargo test` 시 컴파일은 되지만 호출 즉시 패닉.
+
+**관련 코드 위치**: `crates/rpdf-wasm/src/lib.rs` — `#[wasm_bindgen]` impl 블록 내 에러 반환 경로
+
+---
+
+## 해결책
+
+### 원칙: 검증 로직을 JsValue-free 내부 헬퍼로 분리
+
+`#[wasm_bindgen]` 메서드 안에 비즈니스 로직을 직접 작성하지 않는다. 검증·계산 로직은 `JsValue`를 반환하지 않는 내부 헬퍼 함수로 추출하고, wasm 레이어는 변환만 담당한다.
+
+```rust
+// 내부 헬퍼 (JsValue 없음 → 네이티브 cargo test 가능)
+fn validate_delete_indices(indices: &[usize], page_count: usize) -> Result<(), String> {
+    if indices.is_empty() {
+        return Err("삭제할 페이지 목록이 비어있습니다".to_string());
+    }
+    for &i in indices {
+        if i >= page_count {
+            return Err(format!("페이지 인덱스 범위 초과: {}", i));
+        }
+    }
+    Ok(())
+}
+
+fn validate_page_index(idx: usize, count: usize) -> Result<(), String> {
+    if idx >= count {
+        Err(format!("페이지 인덱스 범위 초과: {}", idx))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_degrees(degrees: i32) -> Result<(), String> {
+    match degrees {
+        0 | 90 | 180 | 270 => Ok(()),
+        _ => Err(format!("유효하지 않은 회전각: {} (0/90/180/270만 허용)", degrees)),
+    }
+}
+
+// wasm 레이어 (보일러플레이트만 — 내부 헬퍼 호출 + JsValue 변환)
+#[wasm_bindgen]
+impl PdfDocument {
+    pub fn delete_pages(&mut self, indices: Vec<u32>) -> Result<(), JsValue> {
+        let idx_usize: Vec<usize> = indices.iter().map(|&i| i as usize).collect();
+        validate_delete_indices(&idx_usize, self.doc.page_count())
+            .map_err(|e| JsValue::from(JsError::new(&e)))?;
+        // ...
+    }
+}
+```
+
+### 테스트 패턴
+
+네이티브 단위 테스트에서는 **내부 헬퍼만 직접 테스트**한다.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ut_validate_delete_empty() {
+        let result = validate_delete_indices(&[], 5);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("비어있습니다"));
+    }
+
+    #[test]
+    fn ut_validate_page_index_out_of_bounds() {
+        assert!(validate_page_index(10, 5).is_err());
+        assert!(validate_page_index(4, 5).is_ok());
+    }
+}
+```
+
+---
+
+## 재발 방지
+
+- wasm 크레이트의 `#[wasm_bindgen]` impl 블록에 로직을 직접 작성하지 않는다.
+- `cargo test -p <wasm-crate>`가 CI에 포함되어 있으면 이 패턴이 강제된다.
+- 계획서 작성 시 "내부 헬퍼 분리 전략" 섹션을 명시해야 한다 (Task #25 계획서 참조).
+
+---
+
+## 배운 점
+
+- wasm-bindgen의 JS 타입은 네이티브 단위 테스트에서 "컴파일은 되지만 런타임 패닉"이므로 조심. 링커 에러가 아니라 런타임 패닉이어서 발견이 늦을 수 있다.
+- `#[wasm_bindgen]` 레이어를 얇게 유지하면 WASM 환경 없이도 핵심 로직을 완전히 테스트할 수 있다.
+- `JsValue-free` 헬퍼 패턴은 향후 CLI·WASM 공통 로직에도 재사용 가능하다.
+
+---
+
+## 참고 자료
+
+- wasm-bindgen 공식 문서: https://rustwasm.github.io/docs/wasm-bindgen/
+- 관련 PR: local/task25
+- 계획서: `mydocs/plans/task25-wasm-api.md`

--- a/mydocs/working/task25-done.md
+++ b/mydocs/working/task25-done.md
@@ -1,0 +1,108 @@
+# Task #25 완료 보고서 — wasm_api 모듈 작성
+
+**Issue**: #48  
+**브랜치**: `local/task25`  
+**완료일**: 2026-05-19  
+**마일스톤**: M040 (v0.4 WASM 바인딩)
+
+---
+
+## 구현 결과
+
+`rpdf-wasm` crate를 신규 생성해 JS/TypeScript에서 PDF 파싱·편집·저장 API를 제공한다.
+
+```typescript
+const pdf = new PdfDocument(bytes);          // PDF 로드
+pdf.page_count();                            // 페이지 수
+pdf.page_info(0);                            // { index, rotation, media_box, crop_box }
+pdf.rotate_page(0, 90);                      // 0번 페이지 90도 회전
+pdf.delete_pages([1, 3]);                    // 1, 3번 페이지 삭제
+pdf.undo(); pdf.redo();                      // 실행 취소/다시 실행
+const out = pdf.save();                      // Vec<u8> → Uint8Array
+```
+
+---
+
+## 변경 파일
+
+### 신규
+
+```
+crates/rpdf-wasm/Cargo.toml    — cdylib+rlib, wasm-bindgen 의존
+crates/rpdf-wasm/src/lib.rs    — PdfDocument 전체 구현 (18 테스트)
+mydocs/plans/task25-wasm-api.md
+```
+
+### 수정
+
+```
+Cargo.toml                          — workspace.dependencies에 wasm-bindgen/serde-wasm-bindgen/js-sys 추가
+crates/rpdf-serializer/src/types.rs — PageSource에 #[derive(Clone)] 추가
+```
+
+---
+
+## 체크포인트별 결과
+
+| CP | 내용 | 결과 |
+|----|------|------|
+| CP-A | crate 생성 + wasm-pack 빌드 | ✅ |
+| CP-B | new / page_count / save / page_info | ✅ |
+| CP-C | rotate_page / delete_pages / undo / redo | ✅ |
+| CP-D | wasm-pack release 빌드 + gzip 크기 | ✅ 344KB |
+
+---
+
+## 테스트 결과
+
+```
+cargo test -p rpdf-wasm
+  18 passed; 0 failed
+cargo test (전체 워크스페이스)
+  전체 통과
+wasm-pack build --target web
+  pkg/rpdf_wasm_bg.wasm gzip: 344KB (2MB 이하)
+```
+
+---
+
+## 계획서와 다르게 구현된 사항
+
+| 항목 | 계획서 | 실제 구현 | 이유 |
+|------|--------|----------|------|
+| execute_cmd sources_undo push 방식 | rotate=None, delete=Some 구분 | 항상 push | evaluator 지적: 혼합 커맨드 탈동기화 방지 |
+| UT-07 구현 | delete_pages API 직접 호출 | validate_delete_indices 헬퍼 테스트 | JsError::new 비-wasm 환경 격리 |
+| 테스트 수 | 12개 | 18개 | UT-13 혼합 시나리오 + 내부 헬퍼 테스트 추가 |
+
+---
+
+## plan-eng-review 발견 이슈 처리
+
+| 이슈 | 계획서 반영 | 구현 반영 |
+|------|------------|----------|
+| sources_undo/redo 스냅샷 패턴 | ✅ | ✅ |
+| execute_cmd 타이밍 버그 (Gemini) | ✅ | ✅ |
+| 내부 헬퍼 분리 (Gemini) | ✅ | ✅ |
+| js_sys::Error 사용 (Gemini) | ✅ | ✅ |
+| Vec<u32> 타입 (Gemini) | ✅ | ✅ |
+| 혼합 커맨드 탈동기화 (evaluator) | — | ✅ |
+
+---
+
+## 트러블슈팅 후보 분류
+
+| 항목 | 분류 | 처리 |
+|------|------|------|
+| undo/redo 시 CommandStack과 sources 스택 높이를 항상 일치시켜야 함 — rotate처럼 sources 불변 커맨드도 sentinel push 필요 | A | CLAUDE.md "스택 기반 상태 관리" 사례 추가 |
+| JsError::new()는 비-wasm 네이티브 테스트에서 사용 불가 — 내부 헬퍼를 JsValue-free로 분리해야 네이티브 cargo test 가능 | B | 트러블슈팅 문서 작성 |
+| wasm-pack build 시 Cargo.toml에 description/repository/license 없으면 경고 — npm 배포 전 필수 | C | 완료 보고서 메모 (Task #28에서 처리) |
+
+---
+
+## 완료 기준 달성
+
+1. ✅ `rpdf-wasm` crate 신규 생성, `wasm-pack build --target web` 성공
+2. ✅ `PdfDocument` 공개 API — new, page_count, page_info, rotate_page, delete_pages, save, undo, redo, undo_len, redo_len
+3. ✅ 네이티브 단위 테스트 UT-01~UT-13 (18개) 모두 통과
+4. ✅ `cargo clippy -p rpdf-wasm -- -D warnings` 경고 없음
+5. ✅ WASM 번들 크기 344KB (2MB 이하)


### PR DESCRIPTION
## Summary

- `rpdf-wasm` crate 신규 생성: JS/TypeScript에서 PDF 파싱·편집·저장 API 제공
- `PdfDocument` wasm_bindgen 구조체: `new`, `page_count`, `page_info`, `rotate_page`, `delete_pages`, `save`, `undo`, `redo`, `undo_len`, `redo_len`
- `sources_undo/redo` 스냅샷 패턴으로 undo/redo 시 페이지 소스 동기화 보장
- 내부 로직을 `JsValue-free` 헬퍼로 분리해 `cargo test -p rpdf-wasm` (네이티브) 통과
- `wasm-pack build --target web` 성공, gzip 번들 344KB (2MB 이하)

## Test plan

- [x] `cargo test -p rpdf-wasm` — 18 passed
- [x] `cargo test` (전체 워크스페이스) — 전체 통과
- [x] `cargo clippy -p rpdf-wasm -- -D warnings` — 경고 없음
- [x] `wasm-pack build --target web` — 성공
- [x] gzip 번들 크기: 344KB < 2MB 목표 달성
- [x] UT-13 혼합 커맨드 시나리오 (rotate→delete→undo→undo) sources 일관성 검증

closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)