### PR TITLE
Task #26: PDFium WASM 대체 전략 ADR 및 환경 정비

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ private/`pub(crate)` 함수 테스트 → 인라인 `#[cfg(test)] mod internal_t
 **외부 크레이트**: docs.rs에서 공개 API 확인 완료 후 사용. 계획서에 "공개 API 확인 완료" 명시.
 **CI cargo 도구 설치**: `taiki-e/install-action@<tool-name>` 패턴 사용 (예: `taiki-e/install-action@cargo-nextest`).
 **insta 스냅샷 첫 도입**: 첫 실행 시 `*.snap.new` pending 파일 생성됨 → `cargo insta accept` 또는 수동 rename. CI는 `INSTA_UPDATE=no` 환경변수 필수.
+**wasm-pack build**: `wasm-pack build <크레이트-경로> --target web` — cargo의 `-p` 플래그 미지원, 디렉토리 경로를 직접 지정해야 한다 (예: `wasm-pack build crates/rpdf-wasm --target web`). `-p`를 쓰면 silently 무시되거나 오류 발생.
 
 손으로 만들 것: 워크스페이스 `Cargo.toml`, `pnpm-workspace.yaml`, CI yml, `CLAUDE.md`, `mydocs/`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,13 @@ PDF 스펙(ISO 32000) 용어를 코드에 그대로 반영한다. Don't use tran
 - 올바름: `export PDFIUM_DYNAMIC_LIB_PATH=$(pwd)/pdfium/lib`
 - 잘못됨: `export PDFIUM_DYNAMIC_LIB_PATH=$(pwd)/pdfium/lib/libpdfium.dylib`
 
+### rpdf-wasm에 rpdf-render 의존 추가 금지
+
+`rpdf-wasm`의 `Cargo.toml`에 `rpdf-render` 의존을 추가하면 wasm-pack build가 실패한다.
+`rpdf-render`는 네이티브 PDFium 동적 라이브러리를 런타임에 로딩하므로 WASM 타겟에서 컴파일 불가.
+
+웹 환경 렌더링은 ADR-004에 따라 pdf.js가 담당한다. Rust 코어는 파싱·편집·저장만.
+
 ## 라이선스
 
 기여한 코드는 MIT 라이선스로 배포됩니다.

--- a/crates/rpdf-wasm/Cargo.toml
+++ b/crates/rpdf-wasm/Cargo.toml
@@ -2,6 +2,9 @@
 name = "rpdf-wasm"
 version = "0.1.0"
 edition.workspace = true
+description = "WebAssembly bindings for rpdf — PDF parsing, editing, and saving in the browser"
+repository = "https://github.com/KwonCheulJin/rpdf"
+license = "MIT"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/docs/decisions/ADR-004-wasm-rendering-strategy.md
+++ b/docs/decisions/ADR-004-wasm-rendering-strategy.md
@@ -1,0 +1,57 @@
+# ADR-004: WASM 환경 렌더링 전략 — pdf.js 위임
+
+**날짜**: 2026-05-19
+**상태**: 승인됨
+**결정자**: KwonCheulJin
+**관련**: ADR-001 (크레이트 분리), ADR-002 (pdfium 동적 로딩)
+
+## 맥락
+
+rpdf-wasm (v0.4) crate가 WebAssembly 타겟으로 빌드될 때, 렌더링 기능이 필요하다.
+pdfium-render (rpdf-render의 핵심 의존)는 네이티브 PDFium 동적 라이브러리를 런타임에 로딩하므로
+wasm32-unknown-unknown 타겟에서 사용 불가하다.
+
+세 가지 전략을 검토했다:
+1. PDFium을 WASM으로 직접 컴파일 (google/pdfium-wasm 프로젝트)
+2. 렌더링을 브라우저 JS 측 pdf.js에 위임, Rust 코어는 파싱·편집·저장만
+3. rpdf-svg 자체 렌더러 품질 향상
+
+## 결정
+
+**전략 2 채택**: 웹 환경 렌더링은 pdf.js에 위임한다.
+WASM 번들은 `--target web` 빌드로 브라우저 직접 로딩을 목표로 한다.
+
+**`--target web` 선택 근거**: pdf.js는 브라우저 환경에서 동작하므로, WASM도 브라우저 JS 모듈로
+직접 로딩하는 `--target web`이 가장 자연스러운 통합 방식이다. `--target bundler`는 webpack/vite
+설정이 추가로 필요하고, `--target nodejs`는 서버 환경으로 이 프로젝트의 목적에 부합하지 않는다.
+
+| 작업 | 담당 |
+|------|------|
+| 페이지 렌더링 (화면 표시) | pdf.js |
+| 페이지 썸네일 | pdf.js |
+| 문서 구조 파싱 | Rust (`rpdf-parser`) |
+| 편집 커맨드 (회전·삭제 등) | Rust (`rpdf-edit`) |
+| 저장 (직렬화) | Rust (`rpdf-serializer`) |
+
+## 근거
+
+- **번들 크기**: PDFium WASM 컴파일은 수 MB 규모로 2MB 제한 초과 위험. pdf.js 위임 시 rpdf-wasm은 336KB (gzip)
+- **구현 복잡도**: PDFium WASM 빌드는 별도 빌드 인프라 필요. pdf.js는 이미 성숙한 라이브러리
+- **역할 분리**: ADR-001의 크레이트 분리 원칙과 일관 — rpdf-render는 네이티브 전용, 웹은 pdf.js
+- **유지보수**: PDF 렌더링 품질은 pdf.js 커뮤니티에 위임, Rust 코어는 편집 로직에 집중
+
+## 결과
+
+- `rpdf-wasm`은 `rpdf-render`를 의존하지 않는다
+- WASM 번들에 pdfium 라이브러리가 포함되지 않는다
+- rpdf-studio (Task #29)에서 pdf.js로 렌더링, rpdf-wasm으로 편집·저장을 분담한다
+
+## 알려진 단점
+
+- **이중 파싱**: 같은 PDF를 pdf.js와 Rust 파서가 각각 파싱 (v0.6 이후 개선 검토)
+- **파싱 결과 불일치**: pdf.js와 rpdf-parser의 파싱 결과가 다를 수 있음 (rpdf-studio에서 동기화 레이어 필요)
+
+## 기각된 대안
+
+- **PDFium → WASM 컴파일**: 번들 크기 초과 위험 + 빌드 복잡도
+- **SVG 렌더러 개선**: 시간 소모 과다, v0.6 이후 재검토

--- a/mydocs/plans/task26-wasm-rendering-strategy.md
+++ b/mydocs/plans/task26-wasm-rendering-strategy.md
@@ -1,0 +1,150 @@
+# Task #26 계획서 — PDFium WASM 대체 전략
+
+**Issue**: #50  
+**브랜치**: `local/task26`  
+**마일스톤**: M040 (v0.4 WASM 바인딩)  
+**작성일**: 2026-05-19
+
+---
+
+## 목적
+
+`pdfium-render`는 네이티브 PDFium 동적 라이브러리에 의존하므로 WASM 타겟에서 사용 불가하다.
+웹 환경에서의 렌더링 전략을 확정하고 ADR로 기록한다.
+아울러 `rpdf-wasm` Cargo.toml 메타데이터를 정비하고 Gotcha를 `CONTRIBUTING.md`에 기록한다.
+(pkg/ 제외는 `.gitignore`의 전역 `pkg/` 규칙으로 이미 완료됨)
+
+---
+
+## 배경 조사 (사전 확인)
+
+현재 `rpdf-wasm`의 의존 그래프:
+```
+rpdf-wasm
+├── rpdf-core
+├── rpdf-parser
+├── rpdf-edit
+├── rpdf-serializer
+├── wasm-bindgen
+├── js-sys
+└── serde-wasm-bindgen
+```
+`rpdf-render`(pdfium 의존)가 포함되지 않아 현재도 `wasm-pack build --target web` 성공 (336KB gzip).
+
+---
+
+## 결정된 전략
+
+**옵션 2 채택**: 웹 환경 렌더링은 pdf.js에 위임, Rust 코어는 파싱·편집·저장만 담당.
+
+| 옵션 | 설명 | 기각 이유 |
+|------|------|----------|
+| A: PDFium → WASM 컴파일 | google/pdfium-wasm | 빌드 복잡, 번들 수 MB → 2MB 초과 위험 |
+| B: pdf.js 위임 (채택) | pdf.js 렌더링, Rust 편집/저장 | 간단, 번들 최소 |
+| C: SVG 렌더러 개선 | rpdf-svg 품질 향상 | 시간 소모 과다, v0.6 이후 재검토 |
+
+---
+
+## 범위
+
+### 포함
+
+1. ADR-004 작성 — WASM 렌더링 전략 결정 기록 (`--target web` 선택 근거 포함)
+2. `crates/rpdf-wasm/Cargo.toml` 메타데이터 보강 (description, repository, license)
+3. `CONTRIBUTING.md` Gotcha 추가 — rpdf-wasm에 rpdf-render 의존 추가 금지
+4. `wasm-pack build crates/rpdf-wasm --target web` 재확인 + 번들 크기 측정
+
+### 제외
+
+- pdf.js 통합 코드 (Task #29 rpdf-studio)
+- npm 패키지 구성 (Task #28)
+- CI wasm-pack 빌드 파이프라인 (Task #27)
+
+---
+
+## 체크포인트
+
+### CP-A: ADR + 환경 정비
+
+**체크리스트**:
+- [ ] `docs/decisions/ADR-004-wasm-rendering-strategy.md` 작성 (`--target web` 근거 포함)
+- [ ] `crates/rpdf-wasm/Cargo.toml` — description, repository, license 추가
+- [ ] `CONTRIBUTING.md` — Gotcha 추가 (rpdf-wasm ↔ rpdf-render 격리)
+
+**완료 기준**: ADR 파일 존재, wasm-pack build 경고 메시지 사라짐, CONTRIBUTING.md에 Gotcha 항목
+
+### CP-B: 빌드 재확인
+
+**체크리스트**:
+- [ ] `wasm-pack build crates/rpdf-wasm --target web` 통과
+- [ ] gzip 번들 크기 2MB 이하 확인
+- [ ] `cargo test -p rpdf-wasm` 통과 (18개)
+- [ ] `cargo clippy -p rpdf-wasm -- -D warnings` 경고 없음
+
+---
+
+## 파일 목록
+
+| 파일 | 액션 |
+|------|------|
+| `docs/decisions/ADR-004-wasm-rendering-strategy.md` | 신규 |
+| `crates/rpdf-wasm/Cargo.toml` | 수정 — description/repository/license 추가 |
+| `CONTRIBUTING.md` | 수정 — Gotcha 추가 (rpdf-wasm ↔ rpdf-render 격리) |
+
+---
+
+## 에러 처리
+
+해당 없음 (코드 변경 없음, 빌드 검증만).
+
+---
+
+## 테스트 전략
+
+- `wasm-pack build --target web` 성공 여부
+- gzip 번들 크기 측정 (`gzip -c crates/rpdf-wasm/pkg/*.wasm | wc -c`)
+- `cargo test -p rpdf-wasm` 기존 18개 회귀 통과
+
+---
+
+## 외부 크레이트 변경
+
+없음.
+
+---
+
+## 위험 요소
+
+| 위험 | 대응 |
+|------|------|
+| 향후 rpdf-wasm에 rpdf-render가 실수로 추가될 경우 | ADR-004 + CONTRIBUTING.md Gotcha로 명시 |
+| wasm-opt 없이 번들이 2MB 초과할 경우 | wasm-pack이 자동으로 wasm-opt 실행 (이미 확인됨) |
+
+---
+
+## NOT in scope
+
+- pdf.js 통합 코드 — Task #29
+- npm 패키지 구성 — Task #28
+- CI wasm-pack 빌드 파이프라인 — Task #27
+- PDFium WASM 컴파일 전략 — 번들 크기 초과 위험으로 기각
+
+## What already exists
+
+- `.gitignore`의 전역 `pkg/` 규칙 — crates/rpdf-wasm/pkg/ 이미 제외됨
+- `rpdf-wasm` 의존 그래프 — rpdf-render 없이 이미 wasm-pack build 성공
+- ADR-001 — 크레이트 분리 전략으로 pdfium 격리 이미 결정됨
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAN (PLAN) | 2 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **OUTSIDE VOICE:** Gemini — `.gitignore` 중복 제거, wasm-pack 명령어 수정, CONTRIBUTING.md Gotcha 추가, ADR --target web 근거 명시
+- **UNRESOLVED:** 0
+- **VERDICT:** ENG CLEARED — 계획서 수정 완료, 구현 진행 가능

--- a/mydocs/working/task26-done.md
+++ b/mydocs/working/task26-done.md
@@ -1,0 +1,97 @@
+# Task #26 완료 보고서 — PDFium WASM 대체 전략
+
+**Issue**: #50  
+**브랜치**: `local/task26`  
+**완료일**: 2026-05-19  
+**마일스톤**: M040 (v0.4 WASM 바인딩)
+
+---
+
+## 구현 결과
+
+pdfium-render의 WASM 불가 문제를 해결하기 위한 전략을 ADR로 기록하고, rpdf-wasm 빌드 환경을 정비했다.
+
+**채택된 전략**: pdf.js 렌더링 위임 + Rust 코어 파싱·편집·저장
+
+| 작업 | 담당 |
+|------|------|
+| 페이지 렌더링, 썸네일 | pdf.js |
+| 문서 구조 파싱 | Rust (rpdf-parser) |
+| 편집 커맨드 | Rust (rpdf-edit) |
+| 저장 | Rust (rpdf-serializer) |
+
+---
+
+## 변경 파일
+
+### 신규
+
+```
+docs/decisions/ADR-004-wasm-rendering-strategy.md  — pdf.js 위임 전략 ADR
+mydocs/plans/task26-wasm-rendering-strategy.md     — 계획서
+```
+
+### 수정
+
+```
+crates/rpdf-wasm/Cargo.toml  — description/repository/license 추가
+CONTRIBUTING.md              — rpdf-wasm ↔ rpdf-render 격리 Gotcha 추가
+```
+
+---
+
+## 체크포인트별 결과
+
+| CP | 내용 | 결과 |
+|----|------|------|
+| CP-A | ADR-004 작성 + Cargo.toml 메타데이터 + CONTRIBUTING.md Gotcha | ✅ |
+| CP-B | wasm-pack build 재확인, gzip 336KB, cargo test 18개 통과 | ✅ |
+
+---
+
+## 빌드 검증
+
+```
+wasm-pack build crates/rpdf-wasm --target web  →  성공 (Done in 1.43s)
+gzip 번들 크기: 336KB (2MB 이하)
+cargo test -p rpdf-wasm: 18개 통과
+cargo clippy -p rpdf-wasm -- -D warnings: 경고 없음
+```
+
+---
+
+## 계획서와 다르게 구현된 사항
+
+| 항목 | 계획서 | 실제 구현 | 이유 |
+|------|--------|----------|------|
+| gitignore 추가 | 포함 | 제거 | 전역 `pkg/` 규칙으로 이미 완료됨 |
+| wasm-pack 명령어 | `-p` 플래그 사용 | 디렉토리 경로 사용 | wasm-pack은 `-p` 미지원 (Gemini 지적) |
+
+---
+
+## plan-eng-review 발견 이슈 처리
+
+| 이슈 | 처리 |
+|------|------|
+| .gitignore 중복 제거 (Gemini) | ✅ 계획서에서 제거 |
+| wasm-pack 명령어 수정 (Gemini) | ✅ 계획서 + CP-B 수정 |
+| CONTRIBUTING.md Gotcha 누락 (Gemini) | ✅ 파일 목록 추가 및 구현 |
+| ADR --target web 근거 명시 (Gemini) | ✅ ADR-004에 포함 |
+
+---
+
+## 트러블슈팅 후보 분류
+
+| 항목 | 분류 | 처리 |
+|------|------|------|
+| wasm-pack은 `-p` 플래그 미지원, 디렉토리 경로 필요 | C | 완료 보고서 메모 (cargo 명령어와 혼동하기 쉬움) |
+| Cargo.toml에 license 있어도 루트 LICENSE 파일 없으면 wasm-pack 경고 | C | 완료 보고서 메모 (Task #28에서 처리) |
+
+---
+
+## 완료 기준 달성
+
+1. ✅ ADR-004 작성 — pdf.js 위임 전략, --target web 근거, 기각 대안 포함
+2. ✅ rpdf-wasm이 pdfium-render 없이 wasm-pack build 성공 (이미 달성됨, 재확인)
+3. ✅ CONTRIBUTING.md Gotcha — rpdf-wasm ↔ rpdf-render 격리 명시
+4. ✅ wasm-pack build 통과, 번들 336KB


### PR DESCRIPTION
## Summary

- ADR-004 작성 — pdf.js 위임 전략 결정 기록 (`--target web` 선택 근거, 이중 파싱 단점 포함)
- `crates/rpdf-wasm/Cargo.toml` 메타데이터 보강 (description, repository, license)
- `CONTRIBUTING.md` Gotcha 추가 — rpdf-wasm ↔ rpdf-render 격리 명시

## Test plan

- [x] `wasm-pack build crates/rpdf-wasm --target web` 성공 (Done in 1.43s)
- [x] gzip 번들 크기 336KB (2MB 이하)
- [x] `cargo test -p rpdf-wasm` 18개 통과
- [x] `cargo clippy -p rpdf-wasm -- -D warnings` 경고 없음

closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)