### PR TITLE
Task #27: wasm-pack CI 파이프라인 + @rpdf/core npm 패키지 구성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,37 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # 패키지가 생기면 lint / test / typecheck 추가
+
+  wasm:
+    name: WASM (wasm-pack build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.15.0
+
+      - name: wasm-pack build
+        run: |
+          wasm-pack build crates/rpdf-wasm --target web \
+            --out-dir ../../npm/core \
+            --out-name rpdf_core \
+            --scope rpdf
+          bash scripts/rename-wasm-package.sh
+          # rename 결과 검증 — silent failure 방지
+          grep '"name": "@rpdf/core"' npm/core/package.json || exit 1
+
+      - name: Bundle size check (gzip ≤ 2MB)
+        run: |
+          # .wasm 단독 체크 (.js 글루 코드 ~50KB 포함해도 여유 충분)
+          SIZE=$(gzip -c npm/core/rpdf_core_bg.wasm | wc -c)
+          echo "gzip 번들 크기: ${SIZE} bytes"
+          if [ "$SIZE" -gt 2097152 ]; then
+            echo "❌ 번들 크기 초과: ${SIZE} bytes (상한: 2097152)"
+            exit 1
+          fi
+          echo "✅ 번들 크기 통과: ${SIZE} bytes"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ private/`pub(crate)` 함수 테스트 → 인라인 `#[cfg(test)] mod internal_t
 **CI cargo 도구 설치**: `taiki-e/install-action@<tool-name>` 패턴 사용 (예: `taiki-e/install-action@cargo-nextest`).
 **insta 스냅샷 첫 도입**: 첫 실행 시 `*.snap.new` pending 파일 생성됨 → `cargo insta accept` 또는 수동 rename. CI는 `INSTA_UPDATE=no` 환경변수 필수.
 **wasm-pack build**: `wasm-pack build <크레이트-경로> --target web` — cargo의 `-p` 플래그 미지원, 디렉토리 경로를 직접 지정해야 한다 (예: `wasm-pack build crates/rpdf-wasm --target web`). `-p`를 쓰면 silently 무시되거나 오류 발생.
+  `--out-dir`을 지정하면 wasm-pack 0.15.0이 해당 디렉터리의 `.gitignore`를 `*` 내용으로 덮어쓴다. 빌드 후 반드시 `.gitignore`를 복원할 것 → `CONTRIBUTING.md` "wasm-pack이 `--out-dir`의 `.gitignore`를 덮어씀" 참조.
 
 손으로 만들 것: 워크스페이스 `Cargo.toml`, `pnpm-workspace.yaml`, CI yml, `CLAUDE.md`, `mydocs/`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,26 @@ PDF 스펙(ISO 32000) 용어를 코드에 그대로 반영한다. Don't use tran
 
 웹 환경 렌더링은 ADR-004에 따라 pdf.js가 담당한다. Rust 코어는 파싱·편집·저장만.
 
+### wasm-pack이 `--out-dir`의 `.gitignore`를 덮어씀
+
+`wasm-pack build --out-dir <dir>`을 실행하면 wasm-pack 0.15.0이 해당 디렉터리의 `.gitignore`를
+`*` (모두 무시) 내용으로 **덮어쓴다**. 선생성한 `.gitignore`가 있어도 무시된다.
+
+```bash
+# 올바른 순서
+wasm-pack build crates/rpdf-wasm --target web --out-dir ../../npm/core ...
+# 빌드 후 .gitignore 복원
+cat > npm/core/.gitignore << 'EOF'
+*.wasm
+*.js
+*.d.ts
+snippets/
+EOF
+```
+
+CI에서는 빌드 산출물을 커밋하지 않으므로 영향 없다. 로컬 개발 시 `git status`로 산출물이
+untracked 상태로 남아 있는지 반드시 확인한다.
+
 ## 라이선스
 
 기여한 코드는 MIT 라이선스로 배포됩니다.

--- a/mydocs/plans/task27-wasm-npm-pipeline.md
+++ b/mydocs/plans/task27-wasm-npm-pipeline.md
@@ -1,0 +1,243 @@
+# Task #27 계획서 — wasm-pack CI 파이프라인 + `@rpdf/core` npm 패키지 구성
+
+**Issue**: #52  
+**브랜치**: `local/task27`  
+**마일스톤**: M040 (v0.4 WASM 바인딩)  
+**선행 조건**: Task #26 완료 ✅ (ADR-004, wasm-pack build 성공 336KB)
+
+---
+
+## 목표
+
+1. `npm/core/`를 `@rpdf/core` npm 패키지로 구성 (wasm-pack 출력을 직접 이 디렉터리에 저장)
+2. CI에 `wasm` job 추가 — wasm-pack build + 번들 크기 검증 (gzip 2MB 이하)
+
+---
+
+## 현재 상태
+
+| 항목 | 현황 |
+|------|------|
+| `crates/rpdf-wasm/pkg/` | wasm-pack 기본 출력 (gitignore됨, 로컬 확인용) |
+| `npm/core/` | README.md 플레이스홀더만 존재 (디렉터리 없음) |
+| CI | `rust` job + `node` job (npm install만) |
+| `pnpm-workspace.yaml` | `npm/*` 이미 포함 |
+
+---
+
+## 설계 결정
+
+### wasm-pack 출력 경로
+
+`crates/rpdf-wasm/pkg/`는 로컬 확인용(gitignore)으로 유지하고,
+`npm/core/`를 **npm 패키지 배포 경로**로 분리한다.
+
+```bash
+# --out-dir은 crate 기준 상대경로
+# crates/rpdf-wasm/ + ../../npm/core = npm/core/ (workspace root 기준)
+# ⚠️ CP-A에서 로컬 실행 후 npm/core/에 파일이 생성됨을 반드시 확인
+wasm-pack build crates/rpdf-wasm --target web \
+  --out-dir ../../npm/core \
+  --out-name rpdf_core \
+  --scope rpdf
+```
+
+- `--out-name rpdf_core` → `rpdf_core.js`, `rpdf_core_bg.wasm`, `rpdf_core.d.ts`
+- `--scope rpdf` + `--out-name rpdf_core` → `package.json` name = `@rpdf/rpdf-wasm`
+  (wasm-pack은 crate name 기반으로 name 생성, --out-name은 파일명만 변경)
+- name을 `@rpdf/core`로 변경하기 위한 post-process 스크립트를 추가한다
+
+### npm/core 디렉터리 관리 방침
+
+- wasm-pack 빌드 산출물(`.wasm`, `.js`, `.d.ts`)은 **git에 커밋하지 않는다** (CI에서 매번 재생성)
+- `npm/core/.gitignore`로 빌드 산출물 제외 — **반드시 wasm-pack build 전에 생성**
+- `npm/core/package.json`은 git에 커밋 (wasm-pack 생성본을 post-process 후 저장)
+
+> **이유**: WASM 바이너리는 빌드 재현 가능 산출물이므로 git에 포함할 이유가 없다.
+> package.json은 버전/의존성 선언 파일이므로 커밋한다.
+
+### post-process 방식
+
+wasm-pack이 생성한 `package.json`의 `name` 필드를 `@rpdf/core`로 수정한다.
+
+```bash
+# scripts/rename-wasm-package.sh
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('npm/core/package.json', 'utf8'));
+  p.name = '@rpdf/core';
+  fs.writeFileSync('npm/core/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+```
+
+---
+
+## 파일 변경 목록
+
+### 신규
+
+```
+npm/core/.gitignore          — 빌드 산출물(*.wasm, *.js, *.d.ts) 제외
+npm/core/package.json        — @rpdf/core 패키지 메타데이터 (post-process 결과 커밋)
+scripts/rename-wasm-package.sh — package.json name 후처리 스크립트
+```
+
+### 수정
+
+```
+.github/workflows/ci.yml     — wasm job 추가
+pnpm-lock.yaml               — @rpdf/core workspace 패키지 추가로 변경됨
+```
+
+---
+
+## 체크포인트
+
+### CP-A: npm/core 패키지 구성
+
+**작업**:
+1. `npm/core/.gitignore` 생성 ← **wasm-pack build보다 먼저**
+   ```
+   *.wasm
+   *.js
+   *.d.ts
+   snippets/
+   ```
+2. `scripts/rename-wasm-package.sh` 생성 (위 설계 참조)
+3. 로컬에서 wasm-pack build 실행, **`npm/core/`에 파일이 생성됐는지 확인** (경로 해석 검증 필수)
+   ```bash
+   wasm-pack build crates/rpdf-wasm --target web \
+     --out-dir ../../npm/core \
+     --out-name rpdf_core \
+     --scope rpdf
+   ls npm/core/  # ← rpdf_core.js, rpdf_core_bg.wasm, rpdf_core.d.ts 확인
+   ```
+4. `scripts/rename-wasm-package.sh` 실행, `package.json` name 확인
+   ```bash
+   bash scripts/rename-wasm-package.sh
+   grep '"name": "@rpdf/core"' npm/core/package.json  # 반드시 확인
+   ```
+5. `pnpm install` 실행 후 `pnpm-lock.yaml` 업데이트 확인
+   ```bash
+   pnpm install
+   git diff pnpm-lock.yaml  # @rpdf/core importer 추가 확인
+   ```
+6. `pnpm ls --filter @rpdf/core` — `@rpdf/core` 인식 여부 확인
+7. `npm/core/package.json` 및 `pnpm-lock.yaml` 커밋 (빌드 산출물 제외 확인)
+   ```bash
+   git status  # *.wasm, *.js, *.d.ts가 표시되지 않음을 확인
+   ```
+
+**완료 기준**:
+- `npm/core/package.json`에 `"name": "@rpdf/core"` 확인
+- `pnpm ls --filter @rpdf/core`에서 패키지 인식
+- `npm/core/*.wasm` 등 산출물이 git에 포함되지 않음
+- `pnpm-lock.yaml` 업데이트됨 (커밋 포함)
+
+### CP-B: CI wasm job 추가
+
+**작업**: `.github/workflows/ci.yml`에 `wasm` job 추가
+
+```yaml
+wasm:
+  name: WASM (wasm-pack build)
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
+    - uses: Swatinem/rust-cache@v2
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: wasm-pack@0.15.0
+
+    - name: wasm-pack build
+      run: |
+        wasm-pack build crates/rpdf-wasm --target web \
+          --out-dir ../../npm/core \
+          --out-name rpdf_core \
+          --scope rpdf
+        bash scripts/rename-wasm-package.sh
+        # rename 결과 검증 — silent failure 방지
+        grep '"name": "@rpdf/core"' npm/core/package.json || exit 1
+
+    - name: Bundle size check (gzip ≤ 2MB)
+      run: |
+        # .wasm 단독 체크 (.js 글루 코드 ~50KB 포함해도 여유 충분)
+        SIZE=$(gzip -c npm/core/rpdf_core_bg.wasm | wc -c)
+        echo "gzip 번들 크기: ${SIZE} bytes"
+        if [ "$SIZE" -gt 2097152 ]; then
+          echo "❌ 번들 크기 초과: ${SIZE} bytes (상한: 2097152)"
+          exit 1
+        fi
+        echo "✅ 번들 크기 통과: ${SIZE} bytes"
+```
+
+**완료 기준**:
+- CI `wasm` job 통과
+- `cargo test -p rpdf-wasm` (네이티브)는 기존 `rust` job에서 이미 실행됨 → 별도 추가 불필요
+- 번들 크기 로그에서 gzip 바이트 수 확인
+
+---
+
+## 에러 처리 표
+
+| 에러 상황 | 대응 |
+|----------|------|
+| `wasm32-unknown-unknown` 타겟 미설치 | `dtolnay/rust-toolchain@stable` + `targets: wasm32-unknown-unknown` |
+| `wasm-pack --out-dir` 경로 오류 (npm/core 미생성) | CP-A step 3에서 `ls npm/core/` 확인 필수 |
+| `npm/core/package.json` name 미변경 | `grep` 검증 실패로 CI exit 1 → rename 스크립트 확인 |
+| gzip 크기 초과 | `wasm-opt` 적용 또는 feature flag로 코드 축소 검토 |
+| pnpm이 `@rpdf/core` 미인식 | `pnpm-workspace.yaml`의 `npm/*` 패턴 확인 |
+| CI `node` job `--frozen-lockfile` 실패 | CP-A step 5 `pnpm install` 후 `pnpm-lock.yaml` 커밋 누락 여부 확인 |
+
+---
+
+## 테스트 전략
+
+- **CP-A**: `pnpm ls --filter @rpdf/core`로 패키지 인식 확인
+- **CP-B**: CI `wasm` job 통과 + 번들 크기 로그 확인 + `grep` 검증 통과
+- wasm-bindgen TypeScript 타입(`npm/core/rpdf_core.d.ts`) 유효성은 Task #28(웹 에디터)에서 실사용으로 검증
+
+---
+
+## 도구 버전 (실제 설치)
+
+| 도구 | 버전 |
+|------|------|
+| wasm-pack | 0.15.0 |
+| Rust stable | 1.87.0 (CI: latest stable) |
+| Node | v22.22.0 |
+| pnpm | 10.13.1 |
+
+---
+
+## 범위 외
+
+- npm publish (`@rpdf/core` 실제 배포) → v0.4 완료 후 별도 Task
+- Web Worker / Comlink 래퍼 → Task #28
+- `rpdf-studio` 웹 에디터 → Task #28
+
+---
+
+## 참고
+
+- wasm-pack 설치 Action: `taiki-e/install-action@v2` + `tool: wasm-pack@0.15.0`
+- ADR-004: `docs/decisions/ADR-004-wasm-rendering-strategy.md`
+- v0.4 개요: `mydocs/plans/v0.4-wasm-web.md`
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 4 issues, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **UNRESOLVED:** 0 (D1~D4 모두 결정 완료)
+- **VERDICT:** ENG CLEARED — 계획서 구현 준비 완료

--- a/mydocs/working/task27-done.md
+++ b/mydocs/working/task27-done.md
@@ -1,0 +1,101 @@
+# Task #27 완료 보고서 — wasm-pack CI 파이프라인 + `@rpdf/core` npm 패키지 구성
+
+**Issue**: #52  
+**브랜치**: `local/task27`  
+**완료일**: 2026-05-19  
+**마일스톤**: M040 (v0.4 WASM 바인딩)
+
+---
+
+## 구현 결과
+
+wasm-pack 빌드 산출물을 `npm/core/`로 라우팅하는 파이프라인을 구성하고, CI에 독립 `wasm` job을 추가했다.
+
+| 작업 | 결과 |
+|------|------|
+| `@rpdf/core` npm 패키지 구성 | `npm/core/package.json` — `"name": "@rpdf/core"` |
+| wasm 빌드 산출물 git 제외 | `npm/core/.gitignore` — `*.wasm`, `*.js`, `*.d.ts`, `snippets/` |
+| rename 후처리 스크립트 | `scripts/rename-wasm-package.sh` |
+| CI wasm job | `taiki-e/install-action@v2`, rename 검증, gzip ≤ 2MB 체크 |
+| pnpm workspace 등록 | `pnpm-lock.yaml` — `npm/core: {}` importer 추가 |
+
+---
+
+## 변경 파일
+
+### 신규
+
+```
+npm/core/.gitignore              — 빌드 산출물 git 제외
+npm/core/package.json            — @rpdf/core 패키지 메타데이터
+scripts/rename-wasm-package.sh   — package.json name 후처리 스크립트 (chmod +x)
+mydocs/plans/task27-wasm-npm-pipeline.md — 계획서
+```
+
+### 수정
+
+```
+.github/workflows/ci.yml   — wasm job 추가
+pnpm-lock.yaml             — npm/core importer 추가
+```
+
+---
+
+## 체크포인트별 결과
+
+| CP | 내용 | 결과 |
+|----|------|------|
+| CP-A | npm/core 패키지 구성 + pnpm 등록 + 로컬 wasm-pack 빌드 검증 | ✅ |
+| CP-B | CI wasm job 추가 + evaluator 검증 PASS | ✅ |
+
+---
+
+## 빌드 검증
+
+```
+wasm-pack build crates/rpdf-wasm --target web --out-dir ../../npm/core --out-name rpdf_core --scope rpdf
+→ 성공
+
+gzip npm/core/rpdf_core_bg.wasm: 344KB (2MB 이하 ✅)
+pnpm install: "Scope: all 2 workspace projects" ✅
+git add --dry-run npm/core/: package.json + .gitignore만 ✅
+```
+
+---
+
+## plan-eng-review 발견 이슈 처리
+
+| 이슈 | 처리 |
+|------|------|
+| jetli action → taiki-e/install-action 일관성 (D1) | ✅ taiki-e/install-action@v2 + tool: wasm-pack@0.15.0 |
+| pnpm-lock.yaml 갱신 단계 누락 (D2) | ✅ CP-A에 pnpm install + 커밋 단계 추가 |
+| rename 스크립트 silent failure (D3) | ✅ CI에 grep 검증 step 추가 |
+| 번들 크기 체크 범위 명시 (D4) | ✅ .wasm 단독 + CI 코멘트에 JS ~50KB 명시 |
+
+---
+
+## 계획서와 다르게 구현된 사항
+
+| 항목 | 계획서 | 실제 구현 | 이유 |
+|------|--------|----------|------|
+| `.gitignore` 선생성 후 보호 | 선생성만 언급 | wasm-pack이 `*` 내용으로 덮어씀 → 복원 필요 | wasm-pack 0.15.0이 out-dir의 .gitignore를 항상 덮어씀 |
+
+---
+
+## 트러블슈팅 후보 분류
+
+| 항목 | 분류 | 처리 |
+|------|------|------|
+| wasm-pack이 `--out-dir`의 `.gitignore`를 `*`로 덮어씀 | A | CLAUDE.md 또는 CONTRIBUTING.md에 즉시 반영 |
+| `pnpm ls --filter @rpdf/core` — 의존 패키지 없으면 node_modules 링크 없음 (정상) | C | 완료 보고서 메모 |
+| `--scope rpdf` + `--out-name rpdf_core` 조합 시 package.json name은 `@rpdf/rpdf-wasm` (crate name 기반) | C | 완료 보고서 메모 (rename 스크립트로 처리) |
+
+---
+
+## 완료 기준 달성
+
+1. ✅ `npm/core/package.json`에 `"name": "@rpdf/core"` 확인
+2. ✅ wasm-pack 빌드 산출물 git 미포함 (`.gitignore` 검증)
+3. ✅ pnpm workspace 패키지 인식 (`npm/core: {}` in pnpm-lock.yaml)
+4. ✅ CI `wasm` job — taiki-e/install-action, rename 검증, gzip ≤ 2MB
+5. ✅ evaluator PASS

--- a/npm/core/.gitignore
+++ b/npm/core/.gitignore
@@ -1,0 +1,4 @@
+*.wasm
+*.js
+*.d.ts
+snippets/

--- a/npm/core/package.json
+++ b/npm/core/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@rpdf/core",
+  "type": "module",
+  "description": "WebAssembly bindings for rpdf — PDF parsing, editing, and saving in the browser",
+  "version": "0.1.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/KwonCheulJin/rpdf"
+  },
+  "files": [
+    "rpdf_core_bg.wasm",
+    "rpdf_core.js",
+    "rpdf_core.d.ts"
+  ],
+  "main": "rpdf_core.js",
+  "types": "rpdf_core.d.ts",
+  "sideEffects": [
+    "./snippets/*"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ importers:
         specifier: ^5.4
         version: 5.9.3
 
+  npm/core: {}
+
 packages:
 
   '@types/node@22.19.17':

--- a/scripts/rename-wasm-package.sh
+++ b/scripts/rename-wasm-package.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('npm/core/package.json', 'utf8'));
+  p.name = '@rpdf/core';
+  fs.writeFileSync('npm/core/package.json', JSON.stringify(p, null, 2) + '\n');
+"


### PR DESCRIPTION
## Summary

- `npm/core/`를 `@rpdf/core` pnpm workspace 패키지로 구성 (wasm-pack 빌드 출력 경로 분리)
- CI에 독립 `wasm` job 추가 — `taiki-e/install-action@v2`, rename 검증, gzip ≤ 2MB 체크
- wasm-pack `.gitignore` 덮어쓰기 Gotcha를 CLAUDE.md·CONTRIBUTING.md에 문서화

## Changes

| 파일 | 내용 |
|------|------|
| `npm/core/.gitignore` | 빌드 산출물(`*.wasm`, `*.js`, `*.d.ts`) git 제외 |
| `npm/core/package.json` | `@rpdf/core 0.1.0` 패키지 메타데이터 |
| `scripts/rename-wasm-package.sh` | wasm-pack 생성 name → `@rpdf/core` 후처리 |
| `.github/workflows/ci.yml` | `wasm` job 추가 |
| `pnpm-lock.yaml` | `npm/core` workspace importer 추가 |

## Test plan

- [x] `npm/core/package.json`에 `"name": "@rpdf/core"` 확인
- [x] `git add --dry-run npm/core/` — `package.json` + `.gitignore`만 staging
- [x] `pnpm-lock.yaml`에 `npm/core: {}` importer 추가 확인
- [x] evaluator PASS (CP-A, CP-B 전 항목)
- [ ] CI `wasm` job 통과 (PR 이후 확인)

## Notes

- wasm-pack 0.15.0은 `--out-dir` 지정 시 해당 디렉터리의 `.gitignore`를 `*`로 덮어씀 → 빌드 후 복원 필요 (CONTRIBUTING.md 문서화 완료)
- `@rpdf/core`는 현재 다른 패키지의 의존성이 없어 `node_modules` 링크 없음 — Task #28 rpdf-studio 연결 시 링크됨

closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)